### PR TITLE
RR-1495 - Jackson deserializer to trim prisoner name fields

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/client/StringTrimDeserializer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/client/StringTrimDeserializer.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.client
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+
+/**
+ * A Jackson deserializer that can be used on a String field, performing a full trim on the value before setting the field.
+ */
+class StringTrimDeserializer(vc: Class<*>?) : StdDeserializer<String>(vc) {
+  override fun deserialize(jsonParser: JsonParser, ctxt: DeserializationContext): String = jsonParser.valueAsString.trim()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/client/prisonersearch/PagedPrisonerResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/client/prisonersearch/PagedPrisonerResponse.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.client.prisonersearch
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.client.StringTrimDeserializer
 import java.time.LocalDate
 
 data class PagedPrisonerResponse(
@@ -9,6 +11,7 @@ data class PagedPrisonerResponse(
 )
 
 data class Prisoner(
+  @field:JsonDeserialize(using = StringTrimDeserializer::class)
   val prisonerNumber: String,
   val legalStatus: LegalStatus = LegalStatus.OTHER,
   val releaseDate: LocalDate?,
@@ -17,7 +20,9 @@ data class Prisoner(
   val isIndeterminateSentence: Boolean,
   @field:JsonProperty(value = "recall", defaultValue = "false")
   val isRecall: Boolean,
+  @field:JsonDeserialize(using = StringTrimDeserializer::class)
   val lastName: String,
+  @field:JsonDeserialize(using = StringTrimDeserializer::class)
   val firstName: String,
   val dateOfBirth: LocalDate,
   val cellLocation: String?,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/IntegrationTestBase.kt
@@ -66,4 +66,6 @@ abstract class IntegrationTestBase {
   protected fun stubGetPrisonerNotFoundInPrisonerSearchApi(prisonNumber: String) = hmppsPrisonerSearchApi.stubGetPrisonerNotFound(prisonNumber)
 
   protected fun stubGetPrisonersInPrisonFromPrisonerSearchApi(prisonId: String, response: List<Prisoner>) = hmppsPrisonerSearchApi.stubPrisonersInAPrison(prisonId, response)
+
+  protected fun stubGetPrisonersInPrisonFromPrisonerSearchApi(prisonId: String, response: String) = hmppsPrisonerSearchApi.stubPrisonersInAPrison(prisonId, response)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/wiremock/HmppsPrisonerSearchApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/wiremock/HmppsPrisonerSearchApiMockServer.kt
@@ -58,7 +58,6 @@ class HmppsPrisonerSearchApiMockServer : WireMockServer(WIREMOCK_PORT) {
   }
 
   fun stubPrisonersInAPrison(prisonId: String, response: List<Prisoner>) {
-    println("will return: ${objectMapper.writeValueAsString(PagedPrisonerResponse(last = true, content = response))}")
     stubFor(
       get(urlPathMatching("/prisoner-search/prison/$prisonId"))
         .willReturn(
@@ -66,6 +65,18 @@ class HmppsPrisonerSearchApiMockServer : WireMockServer(WIREMOCK_PORT) {
             .withStatus(200)
             .withHeader("Content-Type", "application/json")
             .withBody(objectMapper.writeValueAsString(PagedPrisonerResponse(last = true, content = response))),
+        ),
+    )
+  }
+
+  fun stubPrisonersInAPrison(prisonId: String, response: String) {
+    stubFor(
+      get(urlPathMatching("/prisoner-search/prison/$prisonId"))
+        .willReturn(
+          responseDefinition()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(response),
         ),
     )
   }

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/resource/model/PersonAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/resource/model/PersonAssert.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model
+
+import org.assertj.core.api.AbstractAssert
+
+fun assertThat(actual: Person?) = PersonAssert(actual)
+
+class PersonAssert(actual: Person?) : AbstractAssert<PersonAssert, Person?>(actual, PersonAssert::class.java) {
+  fun hasPrisonNumber(expected: String): PersonAssert {
+    isNotNull
+    with(actual!!) {
+      if (prisonNumber != expected) {
+        failWithMessage("Expected prisonNumber to be $expected, but was $prisonNumber")
+      }
+    }
+    return this
+  }
+
+  fun hasForename(expected: String): PersonAssert {
+    isNotNull
+    with(actual!!) {
+      if (forename != expected) {
+        failWithMessage("Expected forename to be $expected, but was $forename")
+      }
+    }
+    return this
+  }
+
+  fun hasSurname(expected: String): PersonAssert {
+    isNotNull
+    with(actual!!) {
+      if (surname != expected) {
+        failWithMessage("Expected surname to be $expected, but was $surname")
+      }
+    }
+    return this
+  }
+}

--- a/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/resource/model/SearchByPrisonResponseAssert.kt
+++ b/src/testFixtures/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/resource/model/SearchByPrisonResponseAssert.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model
 
 import org.assertj.core.api.AbstractAssert
+import java.util.function.Consumer
 
 fun assertThat(actual: SearchByPrisonResponse?) = SearchByPrisonResponseAssert(actual)
 
@@ -91,6 +92,53 @@ class SearchByPrisonResponseAssert(actual: SearchByPrisonResponse?) : AbstractAs
       if (people.size != expected) {
         failWithMessage("Expected current page to have $expected records, but was ${people.size}")
       }
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into all child [Person]s. Takes a lambda as the method argument
+   * to call assertion methods provided by [PersonAssert].
+   * Returns this [SearchByPrisonResponseAssert] to allow further chained assertions on the parent [SearchByPrisonResponse]
+   * The assertions on all [Person]s must pass as true.
+   */
+  fun allPeople(consumer: Consumer<PersonAssert>): SearchByPrisonResponseAssert {
+    isNotNull
+    with(actual!!) {
+      people.onEach {
+        consumer.accept(assertThat(it))
+      }
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into the specified child [Person]. Takes a lambda as the method argument
+   * to call assertion methods provided by [PersonAssert].
+   * Returns this [SearchByPrisonResponseAssert] to allow further chained assertions on the parent [SearchByPrisonResponse]
+   *
+   * The `personNumber` parameter is not zero indexed to make for better readability in tests. IE. the first person
+   * should be referenced as `.person(1) { .... }`
+   */
+  fun person(personNumber: Int, consumer: Consumer<PersonAssert>): SearchByPrisonResponseAssert {
+    isNotNull
+    with(actual!!) {
+      val person = people[personNumber - 1]
+      consumer.accept(assertThat(person))
+    }
+    return this
+  }
+
+  /**
+   * Allows for assertion chaining into the specified child [Person]. Takes a lambda as the method argument
+   * to call assertion methods provided by [PersonAssert].
+   * Returns this [SearchByPrisonResponseAssert] to allow further chained assertions on the parent [SearchByPrisonResponse]
+   */
+  fun personWithPrisonNumber(prisonNumber: String, consumer: Consumer<PersonAssert>): SearchByPrisonResponseAssert {
+    isNotNull
+    with(actual!!) {
+      val person = people.firstOrNull { it.prisonNumber == prisonNumber }
+      consumer.accept(assertThat(person))
     }
     return this
   }


### PR DESCRIPTION
PR to fix a bug that Mathusha found whilst testing the search screens in the SAN UI. She found the following prisoner that did not sort and capitalise as expected:

![image](https://github.com/user-attachments/assets/63635a5c-70ea-4909-8ec5-e4a863ab5a80)

The problem is that the prisoner name as returned by prisoner-search-api has a leading space. (this is dev data so is unlikely to happen in prod ... but it could I guess 🤷‍♂️ )
![Screenshot 2025-05-27 at 15 19 25](https://github.com/user-attachments/assets/01c0a8f0-bb2c-4c34-8521-5439346842e8)

Rather than implement a custom setter or getter on the `Person` data class, or write some logic downstream that trims the value, I opted to use a custom Jackson deserializer that could be used on any/as many fields as we find this is a problem for 👍 