### PR TITLE
reference data initial commit

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ReferenceDataEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ReferenceDataEntity.kt
@@ -1,0 +1,51 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.Embedded
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.Immutable
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Immutable
+@Entity
+@Table(name = "reference_data")
+class ReferenceDataEntity(
+  @Embedded
+  val key: ReferenceDataKey,
+  val description: String,
+  val listSequence: Int,
+  val deactivatedAt: LocalDateTime?,
+  val categoryCode: String?,
+  val categoryDescription: String?,
+  val areaCode: String?,
+  val areaDescription: String?,
+  @Id
+  @Column(name = "id")
+  val id: UUID = UUID.randomUUID(),
+) : ReferenceDataLookup by key {
+  fun isActive() = deactivatedAt?.isBefore(LocalDateTime.now()) != true
+}
+
+interface ReferenceDataLookup {
+  val domain: Domain
+  val code: String
+}
+
+@Embeddable
+data class ReferenceDataKey(
+  @Enumerated(EnumType.STRING)
+  override val domain: Domain,
+  override val code: String,
+) : ReferenceDataLookup
+
+enum class Domain {
+  CONDITION,
+  CHALLENGE,
+  STRENGTH,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/repository/ReferenceDataRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/repository/ReferenceDataRepository.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.Domain
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ReferenceDataEntity
+import java.util.*
+
+@Repository
+interface ReferenceDataRepository : JpaRepository<ReferenceDataEntity, UUID> {
+  fun findByKeyDomainOrderByListSequenceAsc(domain: Domain): Collection<ReferenceDataEntity>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/resource/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/resource/ReferenceDataController.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource
+
+import io.swagger.v3.oas.annotations.Parameter
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.Domain
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.ReferenceDataListResponse
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.service.ReferenceDataService
+
+@RestController
+@RequestMapping(path = ["/reference-data/{domain}"])
+class ReferenceDataController(
+  private val referenceDataService: ReferenceDataService,
+) {
+  @GetMapping
+  @PreAuthorize(HAS_VIEW_ELSP)
+  fun getReferenceData(
+    @PathVariable @Parameter(description = "Reference data domain.", required = true) domain: Domain,
+    @Parameter(description = "Include inactive reference data. Defaults to false") includeInactive: Boolean = false,
+  ): ReferenceDataListResponse = ReferenceDataListResponse(referenceDataService.getReferenceDataForDomain(domain, includeInactive))
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/ReferenceDataService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/ReferenceDataService.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.service
+
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.Domain
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.ReferenceDataRepository
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.ReferenceData
+
+@Service
+@Transactional
+class ReferenceDataService(
+  private val referenceDataRepository: ReferenceDataRepository,
+) {
+  fun getReferenceDataForDomain(domain: Domain, includeInactive: Boolean): List<ReferenceData> = referenceDataRepository.findByKeyDomainOrderByListSequenceAsc(domain).filter { includeInactive || it.isActive() }
+    .map {
+      ReferenceData(it.code, it.description, it.listSequence, it.isActive())
+    }
+}

--- a/src/main/resources/db/migration/common/V2025.06.05.0001__add_reference_data_tables.sql
+++ b/src/main/resources/db/migration/common/V2025.06.05.0001__add_reference_data_tables.sql
@@ -1,0 +1,42 @@
+CREATE TABLE reference_data
+(
+    id                  UUID                  PRIMARY KEY NOT NULL,
+    domain              VARCHAR(30)           NOT NULL,
+    code                VARCHAR(60)           NOT NULL,
+    description         VARCHAR(1000)         NOT NULL,
+    category_code        VARCHAR(100)          ,
+    category_description VARCHAR(1000)         ,
+    area_code            VARCHAR(100)          ,
+    area_description     VARCHAR(1000)         ,
+    list_sequence       INT                   ,
+    deactivated_at      TIMESTAMP             ,
+    UNIQUE(domain, code)
+);
+
+create index idx_reference_data_domain
+    on reference_data (domain);
+
+create index idx_reference_data_code
+    on reference_data (code);
+
+
+INSERT INTO reference_data (id, domain, code, description, list_sequence)
+VALUES
+    (gen_random_uuid(), 'CONDITION', 'ABI', 'Acquired Brain Injury', 1),
+    (gen_random_uuid(), 'CONDITION', 'ASC', 'Autism Spectrum Condition', 2),
+    (gen_random_uuid(), 'CONDITION', 'ADHD', 'Attention Deficit Hyperactivity Disorder', 3),
+    (gen_random_uuid(), 'CONDITION', 'DYSLEXIA', 'Dyslexia', 4),
+    (gen_random_uuid(), 'CONDITION', 'DYSPRAXIA', 'Dyspraxia/Developmental Coordination Disorder', 5),
+    (gen_random_uuid(), 'CONDITION', 'DYSCALCULIA', 'Dyscalculia', 6),
+    (gen_random_uuid(), 'CONDITION', 'DYSGRAPHIA', 'Dysgraphia', 7),
+    (gen_random_uuid(), 'CONDITION', 'DLD', 'Developmental Language Disorder', 8),
+    (gen_random_uuid(), 'CONDITION', 'FASD', 'Foetal Alcohol Spectrum disorders', 9),
+    (gen_random_uuid(), 'CONDITION', 'LD', 'Learning Disability', 10),
+    (gen_random_uuid(), 'CONDITION', 'NEURODEGEN', 'Neurodegenerative condition (e.g. dementia, Alzheimer’s)', 11),
+    (gen_random_uuid(), 'CONDITION', 'SENSORY_IMPAIR', 'Sensory impairment (e.g. visual or hearing impairment)', 12),
+    (gen_random_uuid(), 'CONDITION', 'TOURETTES', 'Tourette’s Syndrome/Tic Disorder', 13),
+    (gen_random_uuid(), 'CONDITION', 'MENTAL_HEALTH', 'Other - Mental Health condition (Bi-polar, personality disorder, depression)', 14),
+    (gen_random_uuid(), 'CONDITION', 'PHYSICAL_OTHER', 'Other - Physical condition', 15),
+    (gen_random_uuid(), 'CONDITION', 'NEURO_OTHER', 'Other Neurological / Neurodevelopmental condition (examples could include Epilepsy, Cerebral palsy, etc)', 16),
+    (gen_random_uuid(), 'CONDITION', 'LONG_TERM_MED', 'Long term Medical Condition e.g. Cerebral Palsy, Diabetes, Spina Bifida', 17),
+    (gen_random_uuid(), 'CONDITION', 'OTHER', 'Other disabilities and health conditions', 18);

--- a/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
+++ b/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
@@ -91,8 +91,8 @@ paths:
 
         **Role Requirements:**
         Access to this endpoint requires one of the following roles:
-          - `TODO` (Read-Only)
-          - `TODO` (Read-Write)
+          - `ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RO` (Read-Only)
+          - `ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW` (Read-Write)
 
       tags:
         - Plan
@@ -102,7 +102,41 @@ paths:
         '404':
           $ref: '#/components/responses/404Error'
       operationId: get-plan-creation-schedule
-
+  '/reference-data/{domain}':
+    get:
+      tags:
+        - Reference Data
+      summary: Retrieve all reference data for a domain.
+      description: |-
+        Get all reference data for a domain e.g. CONDITION
+        
+        **Role Requirements:**
+        Access to this endpoint requires one of the following roles:
+          - `ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RO` (Read-Only)
+          - `ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW` (Read-Write)
+      operationId: getReferenceData
+      parameters:
+        - name: domain
+          in: path
+          description: Reference data domain.
+          required: true
+          schema:
+            type: string
+            enum:
+              - CONDITION
+              - CHALLENGE
+              - STRENGTH
+        - name: includeInactive
+          in: query
+          description: Include inactive reference data. Defaults to false
+          required: false
+          schema:
+            type: boolean
+      responses:
+        '200':
+          $ref: '#/components/responses/ReferenceDataResponse'
+        '404':
+          $ref: '#/components/responses/404Error'
 components:
   securitySchemes:
     bearerAuth:
@@ -362,6 +396,40 @@ components:
       required:
         - reviewSchedules
 
+    ReferenceDataListResponse:
+      title: ReferenceDataListResponse
+      description: A list of reference data for a given domain.
+      type: object
+      properties:
+        referenceDataList:
+          type: array
+          description: A List containing zero or more ReferenceDataItem.
+          items:
+            $ref: '#/components/schemas/ReferenceData'
+      required:
+        - referenceDataList
+
+    ReferenceData:
+      type: object
+      description: A reference item belonging to a particular domain
+      properties:
+        code:
+          type: string
+          description: The short code of a reference data
+        description:
+          type: string
+          description: The description of the reference data code
+        listSequence:
+          type: integer
+          format: int32
+          description: 'The sequence number of the code. Used for ordering codes correctly in lists and drop downs. '
+          example: 3
+        active:
+          type: boolean
+          description: whether or not this ref data is active
+      required:
+        - code
+
     ReviewScheduleResponse:
       title: ReviewScheduleResponse
       type: object
@@ -582,6 +650,23 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ReviewSchedulesResponse'
+
+    ReferenceDataResponse:
+      description: Response body containing the a list of reference data.
+      headers:
+        Access-Control-Allow-Origin:
+          schema:
+            type: string
+        Access-Control-Allow-Methods:
+          schema:
+            type: string
+        Access-Control-Allow-Headers:
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ReferenceDataListResponse'
 
     GetPlanCreationSchedule:
       description: Response body containing the a the plan creation schedule.

--- a/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
+++ b/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.1.1
 info:
   title: Support For Additional Needs API
-  version: '0.2.1'
+  version: '0.2.2'
   description: Support For Additional Needs API
   contact:
     name: Learning and Work Progress team
@@ -69,8 +69,8 @@ paths:
 
         **Role Requirements:**
         Access to this endpoint requires one of the following roles:
-          - `TODO` (Read-Only)
-          - `TODO` (Read-Write)
+          - `ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RO` (Read-Only)
+          - `ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW` (Read-Write)
 
       tags:
         - Plan Reviews

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/GetReferenceDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/GetReferenceDataTest.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.resource
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.Domain
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.ReferenceDataListResponse
+
+class GetReferenceDataTest : IntegrationTestBase() {
+  companion object {
+    private const val URI_TEMPLATE = "/reference-data/{domain}"
+  }
+
+  @Test
+  fun `should return a list of CONDITON reference data`() {
+    // Given
+    stubGetTokenFromHmppsAuth()
+
+    // When
+    val response = webTestClient.get()
+      .uri(URI_TEMPLATE, Domain.CONDITION)
+      .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW"), username = "testuser"))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .returnResult(ReferenceDataListResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual).isNotNull()
+    assertThat(actual!!.referenceDataList.size).isEqualTo(18)
+
+    // Example check for specific entry (e.g. code = "ADHD")
+    val adhd = actual.referenceDataList.find { it.code == "ADHD" }
+    assertThat(adhd).isNotNull()
+    assertThat(adhd!!.description).isEqualTo("Attention Deficit Hyperactivity Disorder")
+    assertThat(adhd.listSequence).isEqualTo(3)
+    assertThat(adhd.active).isNotEqualTo(false)
+
+    val firstItem = actual.referenceDataList.minByOrNull { it.listSequence ?: Int.MAX_VALUE }
+    assertThat(firstItem).isNotNull()
+    assertThat(firstItem!!.code).isEqualTo("ABI")
+
+    val lastItem = actual.referenceDataList.maxByOrNull { it.listSequence ?: Int.MIN_VALUE }
+    assertThat(lastItem).isNotNull()
+    assertThat(lastItem!!.code).isEqualTo("OTHER")
+
+    // Ensure no duplicate codes
+    val uniqueCodes = actual.referenceDataList.map { it.code }.toSet()
+    assertThat(uniqueCodes.size).isEqualTo(18)
+
+    // Ensure all entries have non-null descriptions
+    assertThat(actual.referenceDataList).allMatch { it.description != null }
+  }
+}


### PR DESCRIPTION
Endpoint for returning a list of reference data. 

The DOMAIN is the reference data type - so CONDITION, CHALLENGE etc but could also be GENDER, TITLE or whatever in the future. 

The endpoint is simple:

<img width="827" alt="image" src="https://github.com/user-attachments/assets/c7de18ca-01b1-4f2e-b3da-31de46c2af33" />


and will return a list of : 

code,
description, 
listSequence,
active

The code is the code that the database will use in the back end - so if the front end creates a new condition then it will send the code from above. It would be convenient if the description was used in the front end lists as it means any changes or additions/removals could be done with one sql script instead of making actual code changes. The listSequence is the order that they should appear. 

I have also added to the DB but not the endpoint (yet) the concept of Area and Category  - these are optional groupings for ref data. We may or may not use these and they aren't used for CONDITIONS at the moment. 




