### PR TITLE
RR-1559 - Define API spec for create and get Education Support Plan

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/resource/EducationSupportPlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/resource/EducationSupportPlanController.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource
+
+import jakarta.validation.Valid
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.CreateEducationSupportPlanRequest
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.EducationSupportPlanResponse
+
+@RestController
+@RequestMapping("/profile/{prisonNumber}/education-support-plan")
+class EducationSupportPlanController {
+  @PreAuthorize(HAS_VIEW_ELSP)
+  @GetMapping
+  fun getEducationSupportPlan(@PathVariable prisonNumber: String) {
+    TODO("Implement me")
+  }
+
+  @PreAuthorize(HAS_EDIT_ELSP)
+  @PostMapping
+  fun createEducationSupportPlan(
+    @PathVariable prisonNumber: String,
+    @Valid @RequestBody request: CreateEducationSupportPlanRequest,
+  ): EducationSupportPlanResponse {
+    TODO("Implement me")
+  }
+}

--- a/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
+++ b/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
@@ -660,7 +660,7 @@ components:
         prisonId:
           $ref: '#/components/schemas/PrisonId'
           description: The prisonId that the person is a resident at at the time of creating their plan.
-        currentEhcp:
+        hasCurrentEhcp:
           type: boolean
           description: Whether there is a current Education Health Care Plan in place for the person.
           example: true
@@ -709,7 +709,7 @@ components:
           maxLength: 4096
       required:
         - prisonId
-        - currentEhcp
+        - hasCurrentEhcp
         - reviewDate
 
     PlanContributor:
@@ -1023,7 +1023,7 @@ components:
         - $ref: '#/components/schemas/AuditedResource'
       description: A person's Education Support Plan
       properties:
-        currentEhcp:
+        hasCurrentEhcp:
           type: boolean
           description: Whether there is a current Education Health Care Plan in place for the person.
           example: true
@@ -1056,7 +1056,7 @@ components:
           description: Optional details of any support that a Learning Needs Support Practitioner needs to provide.
           example: An LNSP is required for approx 1 hour per week to read and explain passages of text to Chris.
       required:
-        - currentEhcp
+        - hasCurrentEhcp
 
   #
   # Response Body Definitions

--- a/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
+++ b/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.1.1
 info:
   title: Support For Additional Needs API
-  version: '0.2.4'
+  version: '0.3.0'
   description: Support For Additional Needs API
   contact:
     name: Learning and Work Progress team
@@ -53,6 +53,44 @@ paths:
           $ref: '#/components/responses/SearchByPrison'
         '400':
           $ref: '#/components/responses/400Error'
+
+  '/profile/{prisonNumber}/education-support-plan':
+    parameters:
+      - $ref: "#/components/parameters/prisonNumberPathParameter"
+    post:
+      summary: Create an Education Support Plan
+      description: |
+        **Role Requirements:**
+        Access to this endpoint requires one of the following roles:
+          - `ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW` (Read-Write)
+      tags:
+        - Support Plan
+      operationId: create-education-support-plan
+      responses:
+        '201':
+          $ref: '#/components/responses/EducationSupportPlan'
+          description: The Education Support Plan that was created.
+        '400':
+          $ref: '#/components/responses/400Error'
+      requestBody:
+        $ref: '#/components/requestBodies/CreateEducationSupportPlan'
+    get:
+      summary: Return an Education Support Plan
+      description: |
+        **Role Requirements:**
+        Access to this endpoint requires one of the following roles:
+          - `ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RO` (Read-Only)
+          - `ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW` (Read-Write)
+      tags:
+        - Support Plan
+      operationId: get-education-support-plan
+      responses:
+        '200':
+          $ref: '#/components/responses/EducationSupportPlan'
+          description: The Education Support Plan for the specified person.
+        '404':
+          $ref: '#/components/responses/404Error'
+
 
   '/profile/{prisonNumber}/conditions':
     parameters:
@@ -304,6 +342,13 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/UpdateChallengeRequest'
+    CreateEducationSupportPlan:
+      description: Request body to create an Education Support Plan for a person.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreateEducationSupportPlanRequest'
+
   #
   # Schema and Enum Definitions
   # --------------------------------------------------------------------------------
@@ -607,6 +652,83 @@ components:
       required:
         - challenges
 
+    CreateEducationSupportPlanRequest:
+      title: CreateEducationSupportPlanRequest
+      description: A request to create an Education Support Plan for a person.
+      type: object
+      properties:
+        prisonId:
+          $ref: '#/components/schemas/PrisonId'
+          description: The prisonId that the person is a resident at at the time of creating their plan.
+        currentEhcp:
+          type: boolean
+          description: Whether there is a current Education Health Care Plan in place for the person.
+          example: true
+        reviewDate:
+          type: string
+          format: date
+          description: |
+            An ISO-8601 date representing date that the Education Support Plan should be reviewed.
+          example: '2023-11-19'
+        planCreatedBy:
+          description: Optional details of who created the Education Support Plan. If not specified the authenticated user is assumed to have created it.
+          $ref: '#/components/schemas/PlanContributor'
+        otherContributors:
+          description: |
+            Optional list of other people involved in the creation of the Education Support Plan.
+            
+            If provided, the list must contain at least 1 contributor. The list must not be empty.
+          type: array
+          items:
+            $ref: '#/components/schemas/PlanContributor'
+          min: 1
+        learningEnvironmentAdjustments:
+          type: string
+          description: Optional details of any adjustments that are required for the person's learning environment or materials.
+          example: Needs to sit near the front of the class and used coloured overlays for reading text.
+          maxLength: 4096
+        teachingAdjustments:
+          type: string
+          description: Optional details of any adjustments that need to be made to the teaching or curriculum.
+          example: Ensure simple, clear and relevant examples of used when explaining concepts.
+          maxLength: 4096
+        specificTeachingSkills:
+          type: string
+          description: Optional details of any specific teaching skills or knowledge that are required.
+          example: British Sign Language.
+          maxLength: 4096
+        examAccessArrangements:
+          type: string
+          description: Optional details of any exam access arrangements that need to be made.
+          example: Escort Chris to the exam hall 10 minutes before other students to allow him time to settle and collect his thoughts before the exam.
+          maxLength: 4096
+        lnspSupport:
+          type: string
+          description: Optional details of any support that a Learning Needs Support Practitioner needs to provide.
+          example: An LNSP is required for approx 1 hour per week to read and explain passages of text to Chris.
+          maxLength: 4096
+      required:
+        - prisonId
+        - currentEhcp
+        - reviewDate
+
+    PlanContributor:
+      title: PlanContributor
+      description: An object describing someone who contributed to the Education Support Plan
+      type: object
+      properties:
+        name:
+          type: string
+          example: Joe Bloggs
+          maxLength: 200
+        jobRole:
+          type: string
+          example: Education Instructor
+          maxLength: 200
+      required:
+        - name
+        - jobRole
+
     ReferenceDataListResponse:
       title: ReferenceDataListResponse
       description: A list of reference data for a given domain.
@@ -894,6 +1016,47 @@ components:
         - EXEMPT_UNKNOWN
         - COMPLETED
 
+    EducationSupportPlanResponse:
+      title: EducationSupportPlanResponse
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/AuditedResource'
+      description: A person's Education Support Plan
+      properties:
+        currentEhcp:
+          type: boolean
+          description: Whether there is a current Education Health Care Plan in place for the person.
+          example: true
+        planCreatedBy:
+          description: Optional details of who created the Education Support Plan. If not present the plan was created by the createdBy/createdByDisplayName fields.
+          $ref: '#/components/schemas/PlanContributor'
+        otherContributors:
+          description: Optional list of other people involved in the creation of the Education Support Plan.
+          type: array
+          items:
+            $ref: '#/components/schemas/PlanContributor'
+        learningEnvironmentAdjustments:
+          type: string
+          description: Optional details of any adjustments that are required for the person's learning environment or materials.
+          example: Needs to sit near the front of the class and used coloured overlays for reading text.
+        teachingAdjustments:
+          type: string
+          description: Optional details of any adjustments that need to be made to the teaching or curriculum.
+          example: Ensure simple, clear and relevant examples of used when explaining concepts.
+        specificTeachingSkills:
+          type: string
+          description: Optional details of any specific teaching skills or knowledge that are required.
+          example: British Sign Language.
+        examAccessArrangements:
+          type: string
+          description: Optional details of any exam access arrangements that need to be made.
+          example: Escort Chris to the exam hall 10 minutes before other students to allow him time to settle and collect his thoughts before the exam.
+        lnspSupport:
+          type: string
+          description: Optional details of any support that a Learning Needs Support Practitioner needs to provide.
+          example: An LNSP is required for approx 1 hour per week to read and explain passages of text to Chris.
+      required:
+        - currentEhcp
 
   #
   # Response Body Definitions
@@ -1094,6 +1257,23 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/PlanCreationSchedulesResponse'
+
+    EducationSupportPlan:
+      description: Response body containing an Education Support Plan.
+      headers:
+        Access-Control-Allow-Origin:
+          schema:
+            type: string
+        Access-Control-Allow-Methods:
+          schema:
+            type: string
+        Access-Control-Allow-Headers:
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/EducationSupportPlanResponse'
 
 
   #


### PR DESCRIPTION
PR to define the API specs for get and create Education Support Plan endpoints

## Design
### No API fields for Yes/No questions
Whilst the screens ask a Yes/No around each question, the Yes/No feels like a UI concern in respect of how to render the form/show the field. The actual question field is the thing we care about, and if it has a value then we (the UI) can infer the user selected Yes, and if it does not have a value we can infer the user selected No. 
EG: in the following screenshot, as far as the data and the API are concerned, it is only the "details" field we care about, which in this case corresponds to the API field `learningEnvironmentAdjustments`
![Screenshot 2025-06-10 at 08 04 44](https://github.com/user-attachments/assets/e0a255bf-dff0-4106-8c07-56c239be6a24)

Because of this thought process, the request body for the POST endpoint, and the response body for the GET endpoint do not contain yes/no/boolean style fields for each question field. Instead each question field is simply an optional string field.

### Review Date
I'm still not sure about Review Date - I think we need to understand the Review process a little more from the BAs ... but this is my thinking so far ...

In respect of the Create endpoint I think it's right to have a `reviewDate` field. The business process mandates that the user chooses the next review date as part of creating the ELSP, so the API reflecting this feels right I think.
This is not to say I think the DB modelling of an ELSP should include `reviewDate`. Currently I don't think it should, but this PR is only for the API spec ....

... which leads onto the GET endpoint ....
The bit I'm unclear on is (in respect of entity modelling) whether the ELSP has a review date , or whether our Review Schedules will be modelling the review date 🤔 Does the next review date belong to the ELSP, or the current Review Schedule? 🤔 
My gut feeling at the moment (though happy for this to be changed) is that the review date belongs to the Review Schedule, and not the actual ELSP (much like we did for LWP) - but I think we need to properly understand this (specifically the Review lifecycle/process) with the BAs.
As such, as I've designed the API at the moment, the GET endpoint does not include `reviewDate`. My current thinking is that if the UI wants to know the next review date of the ELSP it should do that using the Review Schedule endpoint (because that will deliver richer info than just the review date, such as current status inc. exemption status etc)

## Screenshots
### Create (POST) endpoint
![Screenshot 2025-06-10 at 07 59 44](https://github.com/user-attachments/assets/9151eb8a-5c12-4d2c-b684-0d48ec807388)

### Get (GET) endpoint
![Screenshot 2025-06-10 at 08 00 00](https://github.com/user-attachments/assets/a62d9f4f-7381-4286-b9be-ef4815df9c81)
