### PR TITLE
added ability to chose a challenge at the category level

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ReferenceDataEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ReferenceDataEntity.kt
@@ -26,6 +26,8 @@ class ReferenceDataEntity(
   val categoryDescription: String?,
   val areaCode: String?,
   val areaDescription: String?,
+  val defaultForCategory: Boolean?,
+  val screenerOption: Boolean?,
   @Id
   @Column(name = "id")
   val id: UUID = UUID.randomUUID(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/repository/ReferenceDataRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/repository/ReferenceDataRepository.kt
@@ -14,6 +14,8 @@ import java.util.UUID
 interface ReferenceDataRepository : JpaRepository<ReferenceDataEntity, UUID> {
   fun findByKeyDomainOrderByListSequenceAsc(domain: Domain): Collection<ReferenceDataEntity>
 
+  fun findByKeyDomainAndDefaultForCategoryIsTrueOrderByListSequenceAsc(domain: Domain): Collection<ReferenceDataEntity>
+
   fun findByKey(key: ReferenceDataKey): ReferenceDataEntity?
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/resource/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/resource/ReferenceDataController.kt
@@ -21,4 +21,12 @@ class ReferenceDataController(
     @PathVariable @Parameter(description = "Reference data domain.", required = true) domain: Domain,
     @Parameter(description = "Include inactive reference data. Defaults to false") includeInactive: Boolean = false,
   ): ReferenceDataListResponse = ReferenceDataListResponse(referenceDataService.getReferenceDataForDomain(domain, includeInactive))
+
+  @GetMapping
+  @PreAuthorize(HAS_VIEW_ELSP)
+  @RequestMapping(path = ["/categories"])
+  fun getReferenceDataCategories(
+    @PathVariable @Parameter(description = "Reference data domain.", required = true) domain: Domain,
+    @Parameter(description = "Include inactive reference data. Defaults to false") includeInactive: Boolean = false,
+  ): ReferenceDataListResponse = ReferenceDataListResponse(referenceDataService.getReferenceDataCategoriesDomain(domain, includeInactive))
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/ReferenceDataService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/ReferenceDataService.kt
@@ -24,4 +24,18 @@ class ReferenceDataService(
         it.isActive(),
       )
     }
+
+  fun getReferenceDataCategoriesDomain(domain: Domain, includeInactive: Boolean): List<ReferenceData> = referenceDataRepository.findByKeyDomainAndDefaultForCategoryIsTrueOrderByListSequenceAsc(domain).filter { includeInactive || it.isActive() }
+    .map {
+      ReferenceData(
+        it.code,
+        it.description,
+        it.categoryCode,
+        it.categoryDescription,
+        it.areaCode,
+        it.areaDescription,
+        it.listSequence,
+        it.isActive(),
+      )
+    }
 }

--- a/src/main/resources/db/migration/common/V2025.06.12.0001__default_challenge_ref_data.sql
+++ b/src/main/resources/db/migration/common/V2025.06.12.0001__default_challenge_ref_data.sql
@@ -1,0 +1,31 @@
+ALTER TABLE reference_data
+    ADD COLUMN default_for_category boolean default false,
+    ADD COLUMN screener_option boolean default false;
+
+update reference_data set screener_option = true where domain = 'CHALLENGE';
+update reference_data set default_for_category = false;
+update reference_data set default_for_category = true where domain = 'CHALLENGE' and code = 'MEMORY';
+update reference_data set default_for_category = true where domain = 'CHALLENGE' and code = 'PROCESSING_SPEED';
+
+
+INSERT INTO reference_data (
+    id, domain, code, description,
+    category_code, category_description,
+    area_code, area_description, screener_option, default_for_category,
+    list_sequence
+)
+VALUES
+    (gen_random_uuid(), 'CHALLENGE', 'LITERACY_SKILLS_DEFAULT', 'Literacy Skills', 'LITERACY_SKILLS', 'Literacy Skills', 'COGNITION_LEARNING', 'Cognition & Learning',false, true, 0),
+
+    (gen_random_uuid(), 'CHALLENGE', 'NUMERACY_SKILLS_DEFAULT', 'Numeracy Skills', 'NUMERACY_SKILLS', 'Numeracy Skills', 'COGNITION_LEARNING', 'Cognition & Learning', false, true, 0),
+
+    (gen_random_uuid(), 'CHALLENGE', 'ATTENTION_ORGANISING_TIME_DEFAULT', 'Attention, Organising & Time Management', 'ATTENTION_ORGANISING_TIME', 'Attention, Organising & Time Management', 'COGNITION_LEARNING', 'Cognition & Learning', false, true, 0),
+
+    (gen_random_uuid(), 'CHALLENGE', 'LANGUAGE_COMM_SKILLS_DEFAULT', 'Language & Communication skills', 'LANGUAGE_COMM_SKILLS', 'Language & Communication skills', 'COMMUNICATION_INTERACTION', 'Communication & Interaction', false, true, 0),
+
+    (gen_random_uuid(), 'CHALLENGE', 'EMOTIONS_FEELINGS_DEFAULT', 'Emotions & feelings', 'EMOTIONS_FEELINGS', 'Emotions & feelings', 'SOCIAL_EMOTIONAL_MENTAL', 'Social, Emotional & Mental Health', false, true, 0),
+
+    (gen_random_uuid(), 'CHALLENGE', 'PHYSICAL_SKILLS_DEFAULT', 'Physical Skills & coordination', 'PHYSICAL_SKILLS', 'Physical Skills & coordination', 'PHYSICAL_SENSORY', 'Physical & Sensory', false, true, 0),
+
+    (gen_random_uuid(), 'CHALLENGE', 'SENSORY', 'Sensory', 'SENSORY', 'Sensory', 'PHYSICAL_SENSORY', 'Physical & Sensory', false, true, 0);
+

--- a/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
+++ b/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.1.1
 info:
   title: Support For Additional Needs API
-  version: '0.3.1'
+  version: '0.3.2'
   description: Support For Additional Needs API
   contact:
     name: Learning and Work Progress team
@@ -285,6 +285,48 @@ paths:
           - `ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RO` (Read-Only)
           - `ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW` (Read-Write)
       operationId: getReferenceData
+      parameters:
+        - name: domain
+          in: path
+          description: Reference data domain.
+          required: true
+          schema:
+            type: string
+            enum:
+              - CONDITION
+              - CHALLENGE
+              - STRENGTH
+        - name: includeInactive
+          in: query
+          description: Include inactive reference data. Defaults to false
+          required: false
+          schema:
+            type: boolean
+      responses:
+        '200':
+          $ref: '#/components/responses/ReferenceDataResponse'
+        '404':
+          $ref: '#/components/responses/404Error'
+  '/reference-data/{domain}/categories':
+    get:
+      tags:
+        - Reference Data
+      summary: Retrieve default reference data at the category level.
+      description: |-
+        Each category of reference data can have a default value. So that if someone wants to choose reference data
+        at the category level then this endpoint will return the reference data to be used.  
+        
+        For example in the domain CHALLENGE if someone wants the categories then it will return the default reference data type 
+        for each category currently there are 9 categories. an example of one of them isLITERACY_SKILLS, this will return the 
+        ChallengeType that should be used ie LITERACY_SKILLS_DEFAULT.
+        
+        If no defaults are set for a category then this will return no results. 
+        
+        **Role Requirements:**
+        Access to this endpoint requires one of the following roles:
+          - `ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RO` (Read-Only)
+          - `ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW` (Read-Write)
+      operationId: getReferenceDataCategories
       parameters:
         - name: domain
           in: path

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/GetReferenceDataCategoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/GetReferenceDataCategoryTest.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.resource
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.Domain
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.ReferenceDataListResponse
+
+class GetReferenceDataCategoryTest : IntegrationTestBase() {
+  companion object {
+    private const val URI_TEMPLATE = "/reference-data/{domain}/categories"
+  }
+
+  @Test
+  fun `should return a list of CHALLENGE category reference data`() {
+    // Given
+    stubGetTokenFromHmppsAuth()
+
+    // When
+    val response = webTestClient.get()
+      .uri(URI_TEMPLATE, Domain.CHALLENGE)
+      .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW"), username = "testuser"))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .returnResult(ReferenceDataListResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual).isNotNull()
+    assertThat(actual!!.referenceDataList.size).isEqualTo(9)
+
+    // Ensure no duplicate codes
+    val uniqueCodes = actual.referenceDataList.map { it.code }.toSet()
+    assertThat(uniqueCodes.size).isEqualTo(actual.referenceDataList.size)
+
+    // Ensure all entries have non-null descriptions
+    assertThat(actual.referenceDataList).allMatch { it.description != null }
+  }
+}


### PR DESCRIPTION
Although the screener will chose challenges at the ChallengeType level - the one where there are 64 choices (these have been referred to as balls, needs, challenges) the non screener user journey when creating a challenge currently only allows the creation of challenges at the category level where there are 9 choices.

This change creates reference data to represent these category level challengeTypes and provides an endpoint to return a list of the type codes to be used when creating the challenge.  



