### PR TITLE
Added domain event listener code

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,12 +32,15 @@ val kotlinLoggingVersion = "3.0.5"
 val testContainersVersion = "1.21.1"
 val buildDirectory: Directory = layout.buildDirectory.get()
 val springdocOpenapiVersion = "2.8.9"
+val hmppsSqsVersion = "5.4.5"
+val awaitilityVersion = "4.3.0"
 
 dependencies {
   implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:1.4.6")
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:$springdocOpenapiVersion")
+  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:$hmppsSqsVersion")
 
   implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
 
@@ -45,6 +48,7 @@ dependencies {
   runtimeOnly("org.postgresql:postgresql:$postgresqlVersion")
 
   // Test dependencies
+  testImplementation("org.awaitility:awaitility-kotlin:$awaitilityVersion")
   testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:1.4.6")
   testImplementation("org.wiremock:wiremock-standalone:3.13.1")
   testImplementation("io.swagger.parser.v3:swagger-parser:2.1.29") {
@@ -70,7 +74,7 @@ tasks {
 /*
   `dps-gradle-spring-boot` disabled the jar task in jira DT-2070, specifically to prevent the generation of the
   Spring Boot plain jar. The reason was that the `Dockerfile` copies the Spring Boot fat jar with:
-  `COPY --from=builder --chown=appuser:appgroup /app/build/libs/hmpps-education-and-work-plan-api*.jar /app/app.jar`
+  `COPY --from=builder --chown=appuser:appgroup /app/build/libs/hmpps-support-additional-needs-api*.jar /app/app.jar`
   The fat jar includes the date in the filename, hence needing to use a wildcard. Using the wildcard causes problems
   if there are multiple matching files (eg: the plain jar)
 

--- a/helm_deploy/hmpps-support-additional-needs-api/values.yaml
+++ b/helm_deploy/hmpps-support-additional-needs-api/values.yaml
@@ -42,6 +42,14 @@ generic-service:
       DB_USER: "database_username"
       DB_PASS: "database_password"
 
+    # Inbound SQS config
+    hmpps-domain-events-topic:
+      HMPPS_SQS_TOPICS_DOMAINEVENTS_ARN: "topic_arn"
+    hmpps-support-additional-needs-domain-events-sqs-instance-output:
+      HMPPS_SQS_QUEUES_SUPPORTADDITIONALNEEDS_QUEUE_NAME: "sqs_queue_name"
+    hmpps-support-additional-needs-events-sqs-dl-instance-output:
+      HMPPS_SQS_QUEUES_SUPPORTADDITIONALNEEDS_DLQ_NAME: "sqs_queue_name"
+
   allowlist:
     groups:
       - internal

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/config/RawJsonDeserializer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/config/RawJsonDeserializer.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.config
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.io.IOException
+
+/**
+ * Jackson [JsonDeserializer] that deserializes an object property into a string.
+ *
+ * EG. Given the following JSON where the `additionalInformation` property is an object:
+ * ```
+ *         {
+ *           "description": "A prisoner has been received into prison",
+ *           "version": "1.0",
+ *           "additionalInformation": { "nomsNumber": "A6099EA", "reason": "ADMISSION", "details": "ACTIVE IN:ADM-N", "currentLocation": "IN_PRISON", "prisonId": "SWI", "nomisMovementReasonCode": "N", "currentPrisonStatus": "UNDER_PRISON_CARE" }
+ *         }
+ * ```
+ * The `additionalInformation` can be deserialized into a simple string property as follows:
+ * ```
+ * data class SomeType(
+ *   @JsonDeserialize(using = RawJsonDeserializer::class) val additionalInformation: String,
+ *   val description: String,
+ *   val version: String,
+ * )
+ * ```
+ *
+ */
+class RawJsonDeserializer : JsonDeserializer<String>() {
+  @Throws(IOException::class, JsonProcessingException::class)
+  override fun deserialize(jp: JsonParser, ctxt: DeserializationContext): String {
+    val mapper = jp.codec as ObjectMapper
+    val node = mapper.readTree<JsonNode>(jp)
+    return mapper.writeValueAsString(node)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/messaging/AdditionalInformation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/messaging/AdditionalInformation.kt
@@ -1,0 +1,93 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging
+
+/**
+ * Classes modelling the different structures of Additional Information data for different HMPPS Domain Events.
+ *
+ * HMPPS Domain Events supports additional information pertaining to the event through an untyped property `additionalInformation`
+ * in the event message. Each event type can model additional information as relevant to the event.
+ *
+ * The classes here are used when deserializing the `additionalInformation` property for each event type.
+ */
+sealed class AdditionalInformation {
+  /**
+   * Additional Information for the Prisoner Received Into Prison (prison-offender-events.prisoner.received) HMPPS Domain Event
+   */
+  data class PrisonerReceivedAdditionalInformation(
+    val nomsNumber: String,
+    val reason: Reason,
+    val details: String?,
+    val currentLocation: Location?,
+    val currentPrisonStatus: PrisonStatus?,
+    val prisonId: String,
+    val nomisMovementReasonCode: String,
+  ) : AdditionalInformation() {
+    enum class Reason {
+      ADMISSION,
+      TEMPORARY_ABSENCE_RETURN,
+      RETURN_FROM_COURT,
+      TRANSFERRED,
+    }
+
+    enum class Location {
+      IN_PRISON,
+      OUTSIDE_PRISON,
+      BEING_TRANSFERRED,
+    }
+
+    enum class PrisonStatus {
+      UNDER_PRISON_CARE,
+      NOT_UNDER_PRISON_CARE,
+    }
+  }
+
+  /**
+   * Additional Information for the Prisoner Released From Prison (prison-offender-events.prisoner.released) HMPPS Domain Event
+   */
+  data class PrisonerReleasedAdditionalInformation(
+    val nomsNumber: String,
+    val reason: Reason,
+    val details: String?,
+    val currentLocation: Location?,
+    val currentPrisonStatus: PrisonStatus?,
+    val prisonId: String,
+    val nomisMovementReasonCode: String,
+  ) : AdditionalInformation() {
+
+    val releaseTriggeredByPrisonerDeath: Boolean = nomisMovementReasonCode == "DEC"
+
+    enum class Reason {
+      TEMPORARY_ABSENCE_RELEASE,
+      RELEASED_TO_HOSPITAL,
+      RELEASED,
+      SENT_TO_COURT,
+      TRANSFERRED,
+      UNKNOWN,
+    }
+
+    enum class Location {
+      IN_PRISON,
+      OUTSIDE_PRISON,
+      BEING_TRANSFERRED,
+    }
+
+    enum class PrisonStatus {
+      UNDER_PRISON_CARE,
+      NOT_UNDER_PRISON_CARE,
+    }
+  }
+
+  /**
+   * Additional Information for Prisoner Merged (prison-offender-events.prisoner.merged) HMPPS Domain Event
+   */
+  data class PrisonerMergedAdditionalInformation(
+    val nomsNumber: String,
+    val reason: Reason,
+    val removedNomsNumber: String,
+
+  ) : AdditionalInformation() {
+
+    enum class Reason {
+      MERGE,
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/messaging/EventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/messaging/EventType.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging
+
+import com.fasterxml.jackson.annotation.JsonValue
+
+/**
+ * An enumeration of HMPPS Domain Events that this service consumes and processes.
+ */
+enum class EventType(@JsonValue val eventType: String) {
+  PRISONER_RECEIVED_INTO_PRISON("prison-offender-events.prisoner.received"),
+  PRISONER_RELEASED_FROM_PRISON("prison-offender-events.prisoner.released"),
+  PRISONER_MERGED("prison-offender-events.prisoner.merged"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/messaging/InboundEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/messaging/InboundEvent.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.config.RawJsonDeserializer
+import java.time.Instant
+
+data class InboundEvent(
+  val eventType: EventType,
+  val personReference: PersonReference,
+  @JsonDeserialize(using = RawJsonDeserializer::class) val additionalInformation: String,
+  val occurredAt: Instant,
+  val publishedAt: Instant,
+  val description: String,
+  val version: String,
+) {
+  fun prisonNumber(): String = personReference.identifiers.first { it.type == "NOMS" }.value
+}
+
+data class PersonReference(val identifiers: List<Identifier>)
+
+data class Identifier(val type: String, val value: String)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/messaging/InboundEventsListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/messaging/InboundEventsListener.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.awspring.cloud.sqs.annotation.SqsListener
+import mu.KotlinLogging
+import org.springframework.stereotype.Component
+
+private val log = KotlinLogging.logger {}
+
+private const val NOTIFICATION = "Notification"
+
+/**
+ * Simple SQS Listener class that sends all received "Notification" messages to the [InboundEventsService] for further
+ * processing.
+ */
+@Component
+class InboundEventsListener(
+  private val mapper: ObjectMapper,
+  private val inboundEventsService: InboundEventsService,
+) {
+
+  @SqsListener("suppportadditionalneeds", factory = "hmppsQueueContainerFactoryProxy")
+  internal fun onMessage(sqsMessage: SqsMessage) {
+    log.debug { "Inbound event message: ${sqsMessage.Type}" }
+
+    when (sqsMessage.Type) {
+      NOTIFICATION -> inboundEventsService.process(mapper.readValue(sqsMessage.Message, InboundEvent::class.java))
+      else -> log.info { "Unrecognised message type: ${sqsMessage.Type}" }
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/messaging/InboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/messaging/InboundEventsService.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.AdditionalInformation.PrisonerMergedAdditionalInformation
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Service class that processes SQS events. For each type the [InboundEvent]'s `additionalInformation` property is
+ * deserialized into it's corresponding type, and then the [InboundEvent] and it's [AdditionalInformation] are sent
+ * to the relevant service specific to that event type.
+ */
+@Service
+class InboundEventsService(
+  private val mapper: ObjectMapper,
+) {
+
+  fun process(inboundEvent: InboundEvent) = with(inboundEvent) {
+    log.info { "Processing inbound event $eventType" }
+
+    when (eventType) {
+      EventType.PRISONER_RECEIVED_INTO_PRISON -> {
+        val additionalInformation = eventAdditionalInformation<PrisonerReceivedAdditionalInformation>(inboundEvent)
+        log.info("Received inbound event $eventType with additional information: $additionalInformation")
+      }
+      EventType.PRISONER_RELEASED_FROM_PRISON -> {
+        val additionalInformation = eventAdditionalInformation<PrisonerReleasedAdditionalInformation>(inboundEvent)
+        log.info("Received inbound event $eventType with additional information: $additionalInformation")
+      }
+      EventType.PRISONER_MERGED -> {
+        val additionalInformation = eventAdditionalInformation<PrisonerMergedAdditionalInformation>(inboundEvent)
+        log.info("Received inbound event $eventType with additional information: $additionalInformation")
+      }
+    }
+  }
+
+  private inline fun <reified T : AdditionalInformation> eventAdditionalInformation(inboundEvent: InboundEvent): T = this.mapper.readValue(inboundEvent.additionalInformation, T::class.java)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/messaging/SqsMessage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/messaging/SqsMessage.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+import java.util.UUID
+
+@JsonNaming(value = PropertyNamingStrategies.UpperCamelCaseStrategy::class)
+data class SqsMessage(
+  val Type: String,
+  val Message: String,
+  val MessageId: UUID,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/common/AdditionalInformationBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/common/AdditionalInformationBuilder.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.common
+
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.AdditionalInformation.PrisonerMergedAdditionalInformation
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.AdditionalInformation.PrisonerMergedAdditionalInformation.Reason
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.randomValidPrisonNumber
+
+fun aValidPrisonerReceivedAdditionalInformation(
+  prisonNumber: String = randomValidPrisonNumber(),
+  prisonId: String = "BXI",
+  reason: PrisonerReceivedAdditionalInformation.Reason = PrisonerReceivedAdditionalInformation.Reason.ADMISSION,
+  details: String? = "ACTIVE IN:ADM-N",
+  currentLocation: PrisonerReceivedAdditionalInformation.Location = PrisonerReceivedAdditionalInformation.Location.IN_PRISON,
+  currentPrisonStatus: PrisonerReceivedAdditionalInformation.PrisonStatus = PrisonerReceivedAdditionalInformation.PrisonStatus.UNDER_PRISON_CARE,
+  nomisMovementReasonCode: String = "N",
+): PrisonerReceivedAdditionalInformation = PrisonerReceivedAdditionalInformation(
+  nomsNumber = prisonNumber,
+  reason = reason,
+  details = details,
+  currentLocation = currentLocation,
+  prisonId = prisonId,
+  nomisMovementReasonCode = nomisMovementReasonCode,
+  currentPrisonStatus = currentPrisonStatus,
+)
+
+fun aValidPrisonerReleasedAdditionalInformation(
+  prisonNumber: String = randomValidPrisonNumber(),
+  prisonId: String = "BXI",
+  reason: PrisonerReleasedAdditionalInformation.Reason = PrisonerReleasedAdditionalInformation.Reason.RELEASED,
+  details: String? = "Movement reason code CR",
+  currentLocation: PrisonerReleasedAdditionalInformation.Location = PrisonerReleasedAdditionalInformation.Location.OUTSIDE_PRISON,
+  currentPrisonStatus: PrisonerReleasedAdditionalInformation.PrisonStatus = PrisonerReleasedAdditionalInformation.PrisonStatus.NOT_UNDER_PRISON_CARE,
+  nomisMovementReasonCode: String = "CR",
+): PrisonerReleasedAdditionalInformation = PrisonerReleasedAdditionalInformation(
+  nomsNumber = prisonNumber,
+  reason = reason,
+  details = details,
+  currentLocation = currentLocation,
+  prisonId = prisonId,
+  nomisMovementReasonCode = nomisMovementReasonCode,
+  currentPrisonStatus = currentPrisonStatus,
+)
+
+fun aValidPrisonerMergedAdditionalInformation(
+  prisonNumber: String = randomValidPrisonNumber(),
+  removedNomsNumber: String,
+  reason: Reason = Reason.MERGE,
+): PrisonerMergedAdditionalInformation = PrisonerMergedAdditionalInformation(
+  nomsNumber = prisonNumber,
+  reason = reason,
+  removedNomsNumber = removedNomsNumber,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/common/SqdMessageBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/common/SqdMessageBuilder.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.common
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.AdditionalInformation
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.EventType
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.SqsMessage
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.randomValidPrisonNumber
+import java.time.Instant
+import java.util.UUID
+
+fun aValidHmppsDomainEventsSqsMessage(
+  prisonNumber: String = randomValidPrisonNumber(),
+  eventType: EventType = EventType.PRISONER_RECEIVED_INTO_PRISON,
+  occurredAt: Instant = Instant.now().minusSeconds(10),
+  publishedAt: Instant = Instant.now(),
+  description: String = "A prisoner has been received into prison",
+  version: String = "1.0",
+  removedNomsNumber: String = "",
+  additionalInformation: AdditionalInformation =
+    when (eventType) {
+      EventType.PRISONER_RECEIVED_INTO_PRISON -> aValidPrisonerReceivedAdditionalInformation(prisonNumber)
+      EventType.PRISONER_RELEASED_FROM_PRISON -> aValidPrisonerReleasedAdditionalInformation(prisonNumber)
+      EventType.PRISONER_MERGED -> aValidPrisonerMergedAdditionalInformation(prisonNumber, removedNomsNumber)
+    },
+): SqsMessage = SqsMessage(
+  Type = "Notification",
+  Message = """
+        {
+          "eventType": "${eventType.eventType}",
+          "personReference": { "identifiers": [ { "type": "NOMS", "value": "$prisonNumber" } ] },
+          "occurredAt": "$occurredAt",
+          "publishedAt": "$publishedAt",
+          "description": "$description",
+          "version": "$version",
+          "additionalInformation": ${ObjectMapper().writeValueAsString(additionalInformation)}
+        }        
+  """.trimIndent(),
+  MessageId = UUID.randomUUID(),
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/ResourceSecurityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/ResourceSecurityTest.kt
@@ -50,9 +50,11 @@ class ResourceSecurityTest : IntegrationTestBase() {
   }
 }
 
-private fun RequestMappingInfo.getMappings() = methodsCondition.methods
+private fun RequestMappingInfo.getMappings(): List<String> = methodsCondition.methods
   .map { it.name }
   .ifEmpty { listOf("") } // if no methods defined then match all rather than none
   .flatMap { method ->
-    pathPatternsCondition?.patternValues?.map { "$method $it" } ?: emptyList()
+    pathPatternsCondition?.patternValues
+      ?.filterNot { it.contains("/queue-admin/") } // exclude /queue-admin/ paths
+      ?.map { "$method $it" } ?: emptyList()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/messaging/PrisonerDeathEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/messaging/PrisonerDeathEventTest.kt
@@ -1,0 +1,46 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.messaging
+
+import mu.KotlinLogging
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilCallTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Isolated
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.common.aValidHmppsDomainEventsSqsMessage
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.common.aValidPrisonerReleasedAdditionalInformation
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.EventType
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.randomValidPrisonNumber
+import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
+
+private val log = KotlinLogging.logger {}
+
+@Isolated
+class PrisonerDeathEventTest : IntegrationTestBase() {
+
+  @Test
+  fun `should process prisoner death event`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+
+    val sqsMessage = aValidHmppsDomainEventsSqsMessage(
+      prisonNumber = prisonNumber,
+      eventType = EventType.PRISONER_RELEASED_FROM_PRISON,
+      additionalInformation = aValidPrisonerReleasedAdditionalInformation(
+        prisonNumber = prisonNumber,
+        nomisMovementReasonCode = "DEC",
+      ),
+    )
+
+    // When
+    sendDomainEvent(sqsMessage)
+
+    // Then
+    // wait until the queue is drained / message is processed
+    await untilCallTo {
+      domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+    } matches { it == 0 }
+
+    // TODO() add asserts once the code that processes these messages is finished.
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -29,6 +29,21 @@ manage-users-api:
     id: manage-users-api-client-id
     secret: client-secret
 
+hmpps.sqs:
+  enabled: true
+  provider: localstack
+  queues:
+    suppportadditionalneeds:
+      queueName: support-additional-needs-queue
+      subscribeFilter: "{\"eventType\":[\"prison-offender-events.prisoner.received\", \"prison-offender-events.prisoner.released\"]}"
+      dlqName: support-additional-needs-dead-letter-queue
+      subscribeTopicId: domainevents
+      dlqMaxReceiveCount: 1
+      visibilityTimeout: 1
+  topics:
+    domainevents:
+      arn: arn:aws:sns:eu-west-2:000000000000:domainevents-topic
+
 apis:
   prisoner-search-api:
     url: http://localhost:9093


### PR DESCRIPTION
Added the initial code framework to process the domain events: 

Admission, Merge, Transfer, death, release

This code will simply log that the event has been received, the next PR(s) will process messages and create/update schedules etc. 