### PR TITLE
updated to use envers for entity versioning

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,8 @@ dependencies {
 
   runtimeOnly("org.flywaydb:flyway-database-postgresql")
   runtimeOnly("org.postgresql:postgresql:$postgresqlVersion")
+  implementation("org.hibernate.orm:hibernate-envers")
+  implementation("org.springframework.data:spring-data-envers")
 
   // Test dependencies
   testImplementation("org.awaitility:awaitility-kotlin:$awaitilityVersion")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/AuditRevision.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/AuditRevision.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.envers.RevisionEntity
+import org.hibernate.envers.RevisionNumber
+import org.hibernate.envers.RevisionTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table
+@RevisionEntity
+class AuditRevision {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @RevisionNumber
+  var id: Long = 0
+
+  @RevisionTimestamp
+  var timestamp: LocalDateTime = LocalDateTime.now()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/BaseAuditableEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/BaseAuditableEntity.kt
@@ -14,7 +14,6 @@ import java.util.UUID
 abstract class BaseAuditableEntity {
 
   @Id
-  @Column
   val id: UUID = UUID.randomUUID()
 
   @Column(updatable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/BaseAuditableEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/BaseAuditableEntity.kt
@@ -14,6 +14,7 @@ import java.util.UUID
 abstract class BaseAuditableEntity {
 
   @Id
+  @Column
   val id: UUID = UUID.randomUUID()
 
   @Column(updatable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/PlanCreationScheduleEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/PlanCreationScheduleEntity.kt
@@ -5,13 +5,22 @@ import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
 import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import org.hibernate.envers.Audited
+import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.Instant
 import java.time.LocalDate
+import java.util.*
 
 @Table(name = "plan_creation_schedule")
 @Entity
 @EntityListeners(value = [AuditingEntityListener::class])
+@Audited(withModifiedFlag = false)
 data class PlanCreationScheduleEntity(
 
   @Column(updatable = false)
@@ -32,7 +41,30 @@ data class PlanCreationScheduleEntity(
 
   @Column
   var updatedAtPrison: String,
-) : BaseAuditableEntity()
+
+  @Id
+  @Column
+  val id: UUID = UUID.randomUUID(),
+
+  @Column(updatable = false)
+  val reference: UUID = UUID.randomUUID(),
+
+  @CreatedBy
+  @Column(updatable = false)
+  var createdBy: String? = null,
+
+  @CreationTimestamp
+  @Column(updatable = false)
+  var createdAt: Instant? = null,
+
+  @LastModifiedBy
+  @Column
+  var updatedBy: String? = null,
+
+  @UpdateTimestamp
+  @Column
+  var updatedAt: Instant? = null,
+)
 
 enum class PlanCreationScheduleStatus(val activeReview: Boolean) {
   SCHEDULED(true),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/PlanCreationScheduleEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/PlanCreationScheduleEntity.kt
@@ -15,7 +15,7 @@ import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.Instant
 import java.time.LocalDate
-import java.util.*
+import java.util.UUID
 
 @Table(name = "plan_creation_schedule")
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/PlanCreationScheduleHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/PlanCreationScheduleHistoryEntity.kt
@@ -1,13 +1,13 @@
 package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity
 
 import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.EmbeddedId
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.Id
 import jakarta.persistence.Table
-import org.hibernate.annotations.UuidGenerator
+import org.hibernate.annotations.Immutable
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
@@ -17,47 +17,51 @@ import java.util.UUID
  */
 @Table(name = "plan_creation_schedule_history")
 @Entity
+@Immutable
 data class PlanCreationScheduleHistoryEntity(
 
-  @Column(updatable = false)
+  @Column
   val reference: UUID,
 
-  @Column(updatable = false)
-  val version: Int,
-
-  @Column(updatable = false)
+  @Column(name = "prison_number")
   val prisonNumber: String,
 
-  @Column(updatable = false)
+  @Column(name = "deadline_date")
   val deadlineDate: LocalDate,
 
-  @Column(updatable = false)
+  @Column
   @Enumerated(value = EnumType.STRING)
   val status: PlanCreationScheduleStatus,
 
-  @Column(updatable = false)
+  @Column(name = "exemption_reason")
   val exemptionReason: String?,
 
-  @Column(updatable = false)
+  @Column(name = "created_by")
   val createdBy: String,
 
-  @Column(updatable = false)
+  @Column(name = "created_at")
   val createdAt: Instant,
 
-  @Column(updatable = false)
+  @Column(name = "updated_by")
   val updatedBy: String,
 
-  @Column(updatable = false)
+  @Column(name = "updated_at")
   val updatedAt: Instant,
 
-  @Column(updatable = false)
+  @Column(name = "created_at_prison")
   val createdAtPrison: String,
 
-  @Column(updatable = false)
+  @Column(name = "updated_at_prison")
   val updatedAtPrison: String,
-) {
-  @Id
-  @GeneratedValue
-  @UuidGenerator
-  var id: UUID? = null
-}
+
+  @EmbeddedId
+  val id: PlanCreationScheduleHistoryEntityKey,
+)
+
+@Embeddable
+data class PlanCreationScheduleHistoryEntityKey(
+  @Column
+  val version: Int,
+  @Column(name = "id")
+  val id: UUID,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ReviewScheduleEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ReviewScheduleEntity.kt
@@ -15,7 +15,7 @@ import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.Instant
 import java.time.LocalDate
-import java.util.*
+import java.util.UUID
 
 @Table(name = "review_schedule")
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ReviewScheduleEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ReviewScheduleEntity.kt
@@ -5,13 +5,22 @@ import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
 import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import org.hibernate.envers.Audited
+import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.Instant
 import java.time.LocalDate
+import java.util.*
 
 @Table(name = "review_schedule")
 @Entity
 @EntityListeners(value = [AuditingEntityListener::class])
+@Audited(withModifiedFlag = false)
 data class ReviewScheduleEntity(
 
   @Column(updatable = false)
@@ -32,7 +41,30 @@ data class ReviewScheduleEntity(
 
   @Column
   var updatedAtPrison: String,
-) : BaseAuditableEntity()
+
+  @Id
+  @Column
+  val id: UUID = UUID.randomUUID(),
+
+  @Column(updatable = false)
+  val reference: UUID = UUID.randomUUID(),
+
+  @CreatedBy
+  @Column(updatable = false)
+  var createdBy: String? = null,
+
+  @CreationTimestamp
+  @Column(updatable = false)
+  var createdAt: Instant? = null,
+
+  @LastModifiedBy
+  @Column
+  var updatedBy: String? = null,
+
+  @UpdateTimestamp
+  @Column
+  var updatedAt: Instant? = null,
+)
 
 enum class ReviewScheduleStatus(val activeReview: Boolean) {
   SCHEDULED(true),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ReviewScheduleHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ReviewScheduleHistoryEntity.kt
@@ -1,13 +1,13 @@
 package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity
 
 import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.EmbeddedId
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.Id
 import jakarta.persistence.Table
-import org.hibernate.annotations.UuidGenerator
+import org.hibernate.annotations.Immutable
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
@@ -17,47 +17,51 @@ import java.util.UUID
  */
 @Table(name = "review_schedule_history")
 @Entity
+@Immutable
 data class ReviewScheduleHistoryEntity(
 
-  @Column(updatable = false)
+  @Column
   val reference: UUID,
 
-  @Column(updatable = false)
-  val version: Int,
-
-  @Column(updatable = false)
+  @Column(name = "prison_number")
   val prisonNumber: String,
 
-  @Column(updatable = false)
+  @Column(name = "deadline_date")
   val deadlineDate: LocalDate,
 
-  @Column(updatable = false)
+  @Column
   @Enumerated(value = EnumType.STRING)
   val status: ReviewScheduleStatus,
 
-  @Column(updatable = false)
+  @Column(name = "exemption_reason")
   val exemptionReason: String?,
 
-  @Column(updatable = false)
+  @Column(name = "created_by")
   val createdBy: String,
 
-  @Column(updatable = false)
+  @Column(name = "created_at")
   val createdAt: Instant,
 
-  @Column(updatable = false)
+  @Column(name = "updated_by")
   val updatedBy: String,
 
-  @Column(updatable = false)
+  @Column(name = "updated_at")
   val updatedAt: Instant,
 
-  @Column(updatable = false)
+  @Column(name = "created_at_prison")
   val createdAtPrison: String,
 
-  @Column(updatable = false)
+  @Column(name = "updated_at_prison")
   val updatedAtPrison: String,
-) {
-  @Id
-  @GeneratedValue
-  @UuidGenerator
-  var id: UUID? = null
-}
+
+  @EmbeddedId
+  val id: ReviewScheduleHistoryEntityKey,
+)
+
+@Embeddable
+data class ReviewScheduleHistoryEntityKey(
+  @Column
+  val version: Int,
+  @Column(name = "id")
+  val id: UUID,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/repository/PlanCreationScheduleHistoryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/repository/PlanCreationScheduleHistoryRepository.kt
@@ -1,18 +1,11 @@
 package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleHistoryEntity
 import java.util.UUID
 
 @Repository
 interface PlanCreationScheduleHistoryRepository : JpaRepository<PlanCreationScheduleHistoryEntity, UUID> {
-
-  @Query("SELECT MAX(h.version) FROM PlanCreationScheduleHistoryEntity h WHERE h.reference = :scheduleReference")
-  fun findMaxVersionByScheduleReference(scheduleReference: UUID): Int?
-
-  fun findAllByReference(planCreationScheduleReference: UUID): List<PlanCreationScheduleHistoryEntity>
-
   fun findAllByPrisonNumber(prisonNumber: String): List<PlanCreationScheduleHistoryEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/repository/ReviewScheduleHistoryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/repository/ReviewScheduleHistoryRepository.kt
@@ -1,21 +1,11 @@
 package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository
 
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ReviewScheduleHistoryEntity
 import java.util.UUID
 
 @Repository
 interface ReviewScheduleHistoryRepository : JpaRepository<ReviewScheduleHistoryEntity, UUID> {
-
-  @Query("SELECT MAX(h.version) FROM ReviewScheduleHistoryEntity h WHERE h.reference = :reviewScheduleReference")
-  fun findMaxVersionByReviewScheduleReference(reviewScheduleReference: UUID): Int?
-
-  fun findAllByReference(reviewScheduleReference: UUID): List<ReviewScheduleHistoryEntity>
-
   fun findAllByPrisonNumber(prisonNumber: String): List<ReviewScheduleHistoryEntity>
-  fun getAllByPrisonNumber(prisonNumber: String, pageable: Pageable): Page<ReviewScheduleHistoryEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/mapper/PlanCreationScheduleHistoryMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/mapper/PlanCreationScheduleHistoryMapper.kt
@@ -29,7 +29,7 @@ class PlanCreationScheduleHistoryMapper(
       updatedAt = instantMapper.toOffsetDateTime(updatedAt)!!,
       updatedAtPrison = updatedAtPrison,
       exemptionReason = exemptionReason,
-      version = version,
+      version = entity.id.version,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/mapper/ReviewScheduleHistoryMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/mapper/ReviewScheduleHistoryMapper.kt
@@ -29,7 +29,7 @@ class ReviewScheduleHistoryMapper(
       updatedAt = instantMapper.toOffsetDateTime(updatedAt)!!,
       updatedAtPrison = updatedAtPrison,
       exemptionReason = exemptionReason,
-      version = version,
+      version = entity.id.version,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/PlanCreationScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/PlanCreationScheduleService.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.service
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleEntity
-import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleHistoryEntity
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleStatus
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.PlanCreationScheduleHistoryRepository
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.PlanCreationScheduleRepository
@@ -49,7 +48,7 @@ class PlanCreationScheduleService(
         createdAtPrison = "N/A",
         updatedAtPrison = "N/A",
       )
-      planCreationScheduleRepository.saveAndFlush(planCreationSchedule).also { savePlanCreationScheduleHistory(it) }
+      planCreationScheduleRepository.saveAndFlush(planCreationSchedule)
     }
   }
 
@@ -64,29 +63,7 @@ class PlanCreationScheduleService(
       ?.let {
         it.status = status
         planCreationScheduleRepository.save(it)
-        savePlanCreationScheduleHistory(it)
       }
-  }
-
-  private fun savePlanCreationScheduleHistory(planCreationScheduleEntity: PlanCreationScheduleEntity) {
-    with(planCreationScheduleEntity) {
-      val historyEntry = PlanCreationScheduleHistoryEntity(
-        version = planCreationScheduleHistoryRepository.findMaxVersionByScheduleReference(reference)
-          ?.plus(1) ?: 1,
-        reference = reference,
-        prisonNumber = prisonNumber,
-        createdAtPrison = createdAtPrison,
-        updatedAtPrison = updatedAtPrison,
-        updatedAt = updatedAt!!,
-        createdAt = createdAt!!,
-        updatedBy = updatedBy!!,
-        createdBy = createdBy!!,
-        status = status,
-        exemptionReason = exemptionReason,
-        deadlineDate = deadlineDate,
-      )
-      planCreationScheduleHistoryRepository.save(historyEntry)
-    }
   }
 
   // TODO This needs to be a date from the PES contract date.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/ReviewScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/ReviewScheduleService.kt
@@ -1,8 +1,6 @@
 package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.service
 
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ReviewScheduleEntity
-import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ReviewScheduleHistoryEntity
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ReviewScheduleStatus
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.ReviewScheduleHistoryRepository
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.ReviewScheduleRepository
@@ -26,28 +24,6 @@ class ReviewScheduleService(
       ?.let {
         it.status = status
         reviewScheduleRepository.save(it)
-        saveReviewScheduleHistory(it)
       }
-  }
-
-  private fun saveReviewScheduleHistory(reviewScheduleEntity: ReviewScheduleEntity) {
-    with(reviewScheduleEntity) {
-      val historyEntry = ReviewScheduleHistoryEntity(
-        version = reviewScheduleHistoryRepository.findMaxVersionByReviewScheduleReference(reference)
-          ?.plus(1) ?: 1,
-        reference = reference,
-        prisonNumber = prisonNumber,
-        createdAtPrison = createdAtPrison,
-        updatedAtPrison = updatedAtPrison,
-        updatedAt = updatedAt!!,
-        createdAt = createdAt!!,
-        updatedBy = updatedBy!!,
-        createdBy = createdBy!!,
-        status = status,
-        exemptionReason = exemptionReason,
-        deadlineDate = deadlineDate,
-      )
-      reviewScheduleHistoryRepository.save(historyEntry)
-    }
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,6 +49,12 @@ spring:
     generate-ddl: false
     hibernate:
       ddl-auto: none
+    properties:
+      org.hibernate.envers.audit_table_suffix: _history
+      org.hibernate.envers.revision_field_name: version
+      org.hibernate.envers.revision_type_field_name: rev_type
+      org.hibernate.envers.modified_flag_suffix: _modified
+      org.hibernate.envers.store_data_at_delete: true
 
   datasource:
     url: 'jdbc:postgresql://${DB_SERVER}/${DB_NAME}?sslmode=verify-full'

--- a/src/main/resources/db/migration/common/V2025.06.20.0001__add_envers_support.sql
+++ b/src/main/resources/db/migration/common/V2025.06.20.0001__add_envers_support.sql
@@ -1,0 +1,29 @@
+create table audit_revision
+(
+    id                  bigserial    not null primary key,
+    timestamp           timestamp    not null
+);
+
+ALTER TABLE review_schedule_history
+    ADD COLUMN rev_type smallint;
+
+ALTER TABLE review_schedule_history
+DROP
+CONSTRAINT review_schedule_history_pkey;
+
+ALTER TABLE review_schedule_history
+    ADD PRIMARY KEY (version, id);
+
+ALTER TABLE plan_creation_schedule_history
+    ADD COLUMN rev_type smallint ;
+
+ALTER TABLE plan_creation_schedule_history
+DROP
+CONSTRAINT plan_creation_schedule_history_pkey;
+
+ALTER TABLE plan_creation_schedule_history
+    ADD PRIMARY KEY (version, id);
+
+
+COMMENT ON COLUMN plan_creation_schedule_history.rev_type IS 'Type of change; 0 -> entity was created, 1 -> entity was updated, 2 -> entity was deleted';
+COMMENT ON COLUMN review_schedule_history.rev_type IS 'Type of change; 0 -> entity was created, 1 -> entity was updated, 2 -> entity was deleted';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/IntegrationTestBase.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.client.curious.Lea
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.client.prisonersearch.Prisoner
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleEntity
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleHistoryEntity
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleHistoryEntityKey
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleStatus
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ReviewScheduleEntity
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ReviewScheduleStatus
@@ -187,11 +188,11 @@ abstract class IntegrationTestBase {
       exemptionReason = null,
       createdAtPrison = "BXI",
       updatedAtPrison = "BXI",
-      version = it,
       createdBy = "testuser",
       createdAt = Instant.now(),
       updatedBy = "testuser",
       updatedAt = Instant.now(),
+      id = PlanCreationScheduleHistoryEntityKey(version = 0, id = UUID.randomUUID()),
     )
     planCreationScheduleHistoryRepository.saveAndFlush(planCreationScheduleHistoryEntity)
   }
@@ -211,7 +212,8 @@ abstract class IntegrationTestBase {
         updatedAtPrison = "BXI",
 
       )
-    planCreationScheduleRepository.saveAndFlush(planCreationScheduleEntity)
+    val entity = planCreationScheduleRepository.saveAndFlush(planCreationScheduleEntity)
+    println(entity)
   }
 
   fun aValidReviewScheduleExists(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/messaging/PrisonerDeathEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/messaging/PrisonerDeathEventTest.kt
@@ -37,6 +37,11 @@ class PrisonerDeathEventTest : IntegrationTestBase() {
 
     val schedule = planCreationScheduleRepository.findByPrisonNumber(prisonNumber)
     assertThat(schedule!!.status).isEqualTo(PlanCreationScheduleStatus.EXEMPT_PRISONER_DEATH)
+
+    val history = planCreationScheduleHistoryRepository.findAllByPrisonNumber(prisonNumber)
+    assertThat(history).hasSize(2)
+    assertThat(history[0].id.version).isEqualTo(1)
+    assertThat(history[1].id.version).isEqualTo(2)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/GetReviewSchedulesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/GetReviewSchedulesTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.resou
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ReviewScheduleHistoryEntity
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ReviewScheduleHistoryEntityKey
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ReviewScheduleStatus
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.randomValidPrisonNumber
@@ -53,11 +54,11 @@ class GetReviewSchedulesTest : IntegrationTestBase() {
       exemptionReason = null,
       createdAtPrison = "BXI",
       updatedAtPrison = "BXI",
-      version = it,
       createdBy = "testuser",
       createdAt = Instant.now(),
       updatedBy = "testuser",
       updatedAt = Instant.now(),
+      id = ReviewScheduleHistoryEntityKey(version = 0, id = UUID.randomUUID()),
     )
     reviewScheduleHistoryRepository.saveAndFlush(reviewScheduleHistoryEntity)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/PlanCreationScheduleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/PlanCreationScheduleServiceTest.kt
@@ -12,7 +12,6 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleEntity
-import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleHistoryEntity
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleStatus
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.PlanCreationScheduleHistoryRepository
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.PlanCreationScheduleRepository
@@ -110,7 +109,5 @@ class PlanCreationScheduleServiceTest {
         assert(it.deadlineDate == LocalDate.now().plusDays(10))
       },
     )
-
-    verify(planCreationScheduleHistoryRepository).save(any<PlanCreationScheduleHistoryEntity>())
   }
 }


### PR DESCRIPTION
Rather than manually keeping track of versioning of history entities this PR updates the code to use [Hibernate Envers  ](https://docs.jboss.org/envers/docs/)

May follow this PR with another where the createdby/at etc are also populated by envers but this PR is already pretty big. 