### PR TITLE
more message publishing logic

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,6 +70,10 @@ kotlin {
 tasks {
   withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
+    /* added as a result of this:
+    https://youtrack.jetbrains.com/issue/KT-73255
+     */
+    compilerOptions.freeCompilerArgs.add("-Xannotation-default-target=first-only")
   }
 }
 

--- a/helm_deploy/hmpps-support-additional-needs-api/values.yaml
+++ b/helm_deploy/hmpps-support-additional-needs-api/values.yaml
@@ -20,6 +20,7 @@ generic-service:
     JAVA_OPTS: "-Xmx512m"
     SERVER_PORT: "8080"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
+    PES_CONTRACT_DATE: "2025-10-01"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/PlanCreationScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/PlanCreationScheduleService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.service
 
 import jakarta.transaction.Transactional
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleEntity
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleStatus
@@ -22,6 +23,7 @@ class PlanCreationScheduleService(
   private val educationService: EducationService,
   private val needService: NeedService,
   private val eventPublisher: EventPublisher,
+  @Value("\${pes_contract_date:}") val pesContractDate: LocalDate,
 ) {
 
   /**
@@ -39,6 +41,7 @@ class PlanCreationScheduleService(
       // No plan found — carry on
     }
 
+    // already have a schedule so exit here.
     if (planCreationScheduleRepository.findByPrisonNumber(prisonNumber) != null) return
 
     if (educationService.inEducation(prisonNumber) && needService.hasNeed(prisonNumber)) {
@@ -71,6 +74,9 @@ class PlanCreationScheduleService(
       }
   }
 
-  // TODO This needs to be a date from the PES contract date.
-  private fun getDeadlineDate(): LocalDate = LocalDate.now().plus(10, ChronoUnit.DAYS)
+  fun getDeadlineDate(): LocalDate {
+    val todayPlusTen = LocalDate.now().plus(10, ChronoUnit.DAYS)
+    val pesPlusTen = pesContractDate.plus(10, ChronoUnit.DAYS)
+    return maxOf(todayPlusTen, pesPlusTen)
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/ReviewScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/ReviewScheduleService.kt
@@ -5,6 +5,7 @@ import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.Revi
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.ReviewScheduleHistoryRepository
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.ReviewScheduleRepository
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.mapper.ReviewScheduleHistoryMapper
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.EventPublisher
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.ReviewSchedulesResponse
 
 @Service
@@ -12,6 +13,7 @@ class ReviewScheduleService(
   private val reviewScheduleRepository: ReviewScheduleRepository,
   private val reviewScheduleHistoryRepository: ReviewScheduleHistoryRepository,
   private val reviewScheduleHistoryMapper: ReviewScheduleHistoryMapper,
+  private val eventPublisher: EventPublisher,
 ) {
 
   fun getSchedules(prisonId: String): ReviewSchedulesResponse = ReviewSchedulesResponse(
@@ -24,6 +26,7 @@ class ReviewScheduleService(
       ?.let {
         it.status = status
         reviewScheduleRepository.save(it)
+        eventPublisher.createAndPublishReviewScheduleEvent(prisonNumber)
       }
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -120,3 +120,5 @@ apis:
 
 service:
   base-url: ${SERVICE_BASE_URL}
+
+pes_contract_date: ${PES_CONTRACT_DATE}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -54,3 +54,5 @@ apis:
 
 service:
   base-url: http://localhost:8081
+
+pes_contract_date: "2025-10-01"


### PR DESCRIPTION
In this PR:

A few more places where the plan creation schedule can be changed and therefore messages sent to MN

Added PES contract date logic - ie the date the contracts are due to start. Changing this date will allow us to simulate PES being earlier for testing. 

Spotted many many warnings in our build WRT injected env entries. Not sure how long this has been going on but followed the JetBrains guidance and set the required compiler option. 