### PR TITLE
Updated to not return full history by default.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/repository/PlanCreationScheduleHistoryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/repository/PlanCreationScheduleHistoryRepository.kt
@@ -7,5 +7,5 @@ import java.util.UUID
 
 @Repository
 interface PlanCreationScheduleHistoryRepository : JpaRepository<PlanCreationScheduleHistoryEntity, UUID> {
-  fun findAllByPrisonNumber(prisonNumber: String): List<PlanCreationScheduleHistoryEntity>
+  fun findAllByPrisonNumberOrderByVersionAsc(prisonNumber: String): List<PlanCreationScheduleHistoryEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/resource/PlanCreationScheduleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/resource/PlanCreationScheduleController.kt
@@ -24,8 +24,8 @@ class PlanCreationScheduleController(private val planCreationScheduleService: Pl
   @GetMapping
   fun getPlanCreationSchedules(
     @PathVariable prisonNumber: String,
-    @RequestParam(name = "includePastSchedules", defaultValue = "false") includePastSchedules: Boolean,
-  ): PlanCreationSchedulesResponse = planCreationScheduleService.getSchedules(prisonNumber, includePastSchedules)
+    @RequestParam(name = "includeAllHistory", defaultValue = "false") includeAllHistory: Boolean,
+  ): PlanCreationSchedulesResponse = planCreationScheduleService.getSchedules(prisonNumber, includeAllHistory)
 
   @PreAuthorize(HAS_EDIT_ELSP)
   @PatchMapping("/status")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/resource/PlanCreationScheduleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/resource/PlanCreationScheduleController.kt
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.PlanCreationSchedulesResponse
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.PlanCreationUpdateStatus
@@ -23,7 +24,8 @@ class PlanCreationScheduleController(private val planCreationScheduleService: Pl
   @GetMapping
   fun getPlanCreationSchedules(
     @PathVariable prisonNumber: String,
-  ): PlanCreationSchedulesResponse = planCreationScheduleService.getSchedules(prisonNumber)
+    @RequestParam(name = "includePastSchedules", defaultValue = "false") includePastSchedules: Boolean,
+  ): PlanCreationSchedulesResponse = planCreationScheduleService.getSchedules(prisonNumber, includePastSchedules)
 
   @PreAuthorize(HAS_EDIT_ELSP)
   @PatchMapping("/status")
@@ -40,7 +42,7 @@ class PlanCreationScheduleController(private val planCreationScheduleService: Pl
       updatedAtPrison = request.prisonId,
       clearDeadlineDate = true,
     )
-    return planCreationScheduleService.getSchedules(prisonNumber)
+    return planCreationScheduleService.getSchedules(prisonNumber, false)
   }
 
   fun mapStatus(status: PlanCreationUpdateStatus): PlanCreationScheduleStatusEntity = when (status) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/PlanCreationScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/PlanCreationScheduleService.kt
@@ -54,11 +54,11 @@ class PlanCreationScheduleService(
     }
   }
 
-  fun getSchedules(prisonId: String, includePastSchedules: Boolean): PlanCreationSchedulesResponse {
+  fun getSchedules(prisonId: String, includeAllHistory: Boolean): PlanCreationSchedulesResponse {
     val schedules = planCreationScheduleHistoryRepository
       .findAllByPrisonNumberOrderByVersionAsc(prisonId)
 
-    val models = if (includePastSchedules) {
+    val models = if (includeAllHistory) {
       schedules.map { planCreationScheduleHistoryMapper.toModel(it) }
     } else {
       schedules.maxByOrNull { it.version!! }

--- a/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
+++ b/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
@@ -280,6 +280,13 @@ paths:
   '/profile/{prisonNumber}/plan-creation-schedule':
     parameters:
       - $ref: "#/components/parameters/prisonNumberPathParameter"
+      - name: includePastSchedules
+        in: query
+        description: Whether to include past plan creation schedules
+        required: false
+        schema:
+          type: boolean
+          default: false
     get:
       summary: Returns the plan creation Schedule for a prisoner
       description: |

--- a/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
+++ b/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.1.1
 info:
   title: Support For Additional Needs API
-  version: '0.4.0'
+  version: '0.4.1'
   description: Support For Additional Needs API
   contact:
     name: Learning and Work Progress team
@@ -280,9 +280,9 @@ paths:
   '/profile/{prisonNumber}/plan-creation-schedule':
     parameters:
       - $ref: "#/components/parameters/prisonNumberPathParameter"
-      - name: includePastSchedules
+      - name: includeAllHistory
         in: query
-        description: Whether to include past plan creation schedules
+        description: Whether to include the history of the schedule changes
         required: false
         schema:
           type: boolean

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/messaging/PrisonerDeathEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/messaging/PrisonerDeathEventTest.kt
@@ -38,7 +38,7 @@ class PrisonerDeathEventTest : IntegrationTestBase() {
     val schedule = planCreationScheduleRepository.findByPrisonNumber(prisonNumber)
     assertThat(schedule!!.status).isEqualTo(PlanCreationScheduleStatus.EXEMPT_PRISONER_DEATH)
 
-    val history = planCreationScheduleHistoryRepository.findAllByPrisonNumber(prisonNumber)
+    val history = planCreationScheduleHistoryRepository.findAllByPrisonNumberOrderByVersionAsc(prisonNumber)
     assertThat(history).hasSize(2)
     assertThat(history[0].version).isEqualTo(0)
     assertThat(history[1].version).isEqualTo(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/GetPlanCreationSchedulesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/GetPlanCreationSchedulesTest.kt
@@ -56,7 +56,7 @@ class GetPlanCreationSchedulesTest : IntegrationTestBase() {
       .uri { uriBuilder ->
         uriBuilder
           .path(URI_TEMPLATE)
-          .queryParam("includePastSchedules", true)
+          .queryParam("includeAllHistory", true)
           .build(prisonNumber)
       }
       .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW"), username = "testuser"))
@@ -92,7 +92,7 @@ class GetPlanCreationSchedulesTest : IntegrationTestBase() {
       .uri { uriBuilder ->
         uriBuilder
           .path(URI_TEMPLATE)
-          .queryParam("includePastSchedules", false)
+          .queryParam("includeAllHistory", false)
           .build(prisonNumber)
       }
       .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW"), username = "testuser"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/GetPlanCreationSchedulesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/GetPlanCreationSchedulesTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.resou
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleStatus
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.PlanCreationSchedulesResponse
@@ -35,6 +36,76 @@ class GetPlanCreationSchedulesTest : IntegrationTestBase() {
 
     assertThat(actual).isNotNull()
     assertThat(actual!!.planCreationSchedules[0].status).isEqualTo(PlanCreationStatus.SCHEDULED)
+    assertThat(actual.planCreationSchedules[0].deadlineDate).isEqualTo(LocalDate.now().minusMonths(1))
+  }
+
+  @Test
+  fun `should return plan creation schedules where there are multiple versions`() {
+    // Given
+    stubGetTokenFromHmppsAuth()
+    stubGetDisplayName("testuser")
+    val prisonNumber = randomValidPrisonNumber()
+    aValidPlanCreationScheduleExists(prisonNumber)
+    val schedule = planCreationScheduleRepository.findByPrisonNumber(prisonNumber)
+    // update the schedule
+    schedule!!.status = PlanCreationScheduleStatus.COMPLETED
+    planCreationScheduleRepository.save(schedule)
+
+    // When
+    val response = webTestClient.get()
+      .uri { uriBuilder ->
+        uriBuilder
+          .path(URI_TEMPLATE)
+          .queryParam("includePastSchedules", true)
+          .build(prisonNumber)
+      }
+      .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW"), username = "testuser"))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .returnResult(PlanCreationSchedulesResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+
+    assertThat(actual).isNotNull()
+    assertThat(actual!!.planCreationSchedules[0].status).isEqualTo(PlanCreationStatus.SCHEDULED)
+    assertThat(actual.planCreationSchedules[0].deadlineDate).isEqualTo(LocalDate.now().minusMonths(1))
+    assertThat(actual.planCreationSchedules[1].status).isEqualTo(PlanCreationStatus.COMPLETED)
+    assertThat(actual.planCreationSchedules[1].deadlineDate).isEqualTo(LocalDate.now().minusMonths(1))
+  }
+
+  @Test
+  fun `should return single creation schedule history where there are multiple versions`() {
+    // Given
+    stubGetTokenFromHmppsAuth()
+    stubGetDisplayName("testuser")
+    val prisonNumber = randomValidPrisonNumber()
+    aValidPlanCreationScheduleExists(prisonNumber)
+    val schedule = planCreationScheduleRepository.findByPrisonNumber(prisonNumber)
+    // update the schedule
+    schedule!!.status = PlanCreationScheduleStatus.COMPLETED
+    planCreationScheduleRepository.save(schedule)
+
+    // When
+    val response = webTestClient.get()
+      .uri { uriBuilder ->
+        uriBuilder
+          .path(URI_TEMPLATE)
+          .queryParam("includePastSchedules", false)
+          .build(prisonNumber)
+      }
+      .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW"), username = "testuser"))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .returnResult(PlanCreationSchedulesResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+
+    assertThat(actual).isNotNull()
+    assertThat(actual!!.planCreationSchedules[0].status).isEqualTo(PlanCreationStatus.COMPLETED)
     assertThat(actual.planCreationSchedules[0].deadlineDate).isEqualTo(LocalDate.now().minusMonths(1))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/UpdatePlanCreationScheduleStatusTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/UpdatePlanCreationScheduleStatusTest.kt
@@ -45,11 +45,11 @@ class UpdatePlanCreationScheduleStatusTest : IntegrationTestBase() {
     val actual = response.responseBody.blockFirst()
 
     assertThat(actual).isNotNull()
-    assertThat(actual!!.planCreationSchedules[1].status).isEqualTo(PlanCreationStatus.EXEMPT_PRISONER_NOT_COMPLY)
-    assertThat(actual.planCreationSchedules[1].deadlineDate).isNull()
-    assertThat(actual.planCreationSchedules[1].exemptionReason).isEqualTo(PlanCreationScheduleExemptionReason.EXEMPT_NOT_REQUIRED)
-    assertThat(actual.planCreationSchedules[1].exemptionDetail).isEqualTo("because I say so")
-    assertThat(actual.planCreationSchedules[1].updatedAtPrison).isEqualTo("LWI")
+    assertThat(actual!!.planCreationSchedules[0].status).isEqualTo(PlanCreationStatus.EXEMPT_PRISONER_NOT_COMPLY)
+    assertThat(actual.planCreationSchedules[0].deadlineDate).isNull()
+    assertThat(actual.planCreationSchedules[0].exemptionReason).isEqualTo(PlanCreationScheduleExemptionReason.EXEMPT_NOT_REQUIRED)
+    assertThat(actual.planCreationSchedules[0].exemptionDetail).isEqualTo("because I say so")
+    assertThat(actual.planCreationSchedules[0].updatedAtPrison).isEqualTo("LWI")
   }
 
   @Test


### PR DESCRIPTION
Added includeAllHistory request param to make things a bit easier on the front end - this defaults to false: 
Essentially the default version of the endpoint returns only the latest status of the plan creation schedule, rather than the full history. if you want the full history pass in includeAllHistory=true


<img width="847" alt="image" src="https://github.com/user-attachments/assets/1ba9d8b2-bc26-4d73-8c44-462332e3ec3f" />
