### PR TITLE
RR-1641 - Added new field to capture prisoners requirements and needs for education support

### DIFF
--- a/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
+++ b/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.1.1
 info:
   title: Support For Additional Needs API
-  version: '0.4.2'
+  version: '0.4.3'
   description: Support For Additional Needs API
   contact:
     name: Learning and Work Progress team
@@ -818,6 +818,11 @@ components:
           description: Optional Additional information about the plan that is not covered in the other questions.
           example: Chris is very open about his issues and is a pleasure to talk to.
           maxLength: 4096
+        individualSupport:
+          type: string
+          description: Details of education support that the person feels they need or would benefit from.
+          example: Chris is sensitive to loud noises and has asked for a quieter position in a calm classroom.
+          maxLength: 4096
       required:
         - prisonId
         - hasCurrentEhcp
@@ -1260,7 +1265,10 @@ components:
           type: string
           description: Optional Additional information about the plan that is not covered in the other questions.
           example: Chris is very open about his issues and is a pleasure to talk to.
-          maxLength: 4096
+        individualSupport:
+          type: string
+          description: Details of education support that the person feels they need or would benefit from.
+          example: Chris is sensitive to loud noises and has asked for a quieter position in a calm classroom.
       required:
         - hasCurrentEhcp
 


### PR DESCRIPTION
PR to add a new field to the swagger spec for Create and Get an Education Support Plan.

The new field is to capture the data on the new UI screen 'What support in education does [prisoner name] feel they need?'
IE. The user will be asking the prisoner what support _they_ think they need as well as all the other questions.

Difficult to come up with a good field name, but in the end I opted for `individualSupport`; but am open to suggestions of a better name.

At the moment the field is non-mandatory, which means I've not had to provide any implementation etc. Once the UI is complete we can come back, mark the field as mandatory in the spec, and provide the impl re: DB column, mapping etc.

Doing it this way allows the UI to import the spec to know about the new field, and to start sending the data to the API, even though nothing will happen with it at this stage. (ie. managing what is otherwise a breaking change)