### PR TITLE
RR-1500 - Implement Search API query string validation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/resource/SearchController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/resource/SearchController.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource
 
 import jakarta.validation.constraints.Min
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -18,6 +19,7 @@ import kotlin.math.min
 
 @RestController
 @RequestMapping("/search/prisons/{prisonId}/people")
+@Validated
 class SearchController(private val searchService: SearchService) {
   @GetMapping
   @PreAuthorize(HAS_SEARCH_PRISONS)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/SearchByPrisonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/SearchByPrisonTest.kt
@@ -223,4 +223,81 @@ class SearchByPrisonTest : IntegrationTestBase() {
       .hasStatus(HttpStatus.BAD_REQUEST.value())
       .hasUserMessageContaining("Method parameter 'pageSize': Failed to convert value of type 'java.lang.String' to required type")
   }
+
+  @Test
+  fun `should return bad request given request with page value less than 1`() {
+    // Given
+
+    // When
+    val response = webTestClient.get()
+      .uri { uriBuilder ->
+        uriBuilder
+          .path(DefaultUriBuilderFactory().expand(URI_TEMPLATE, PRISON_ID).path)
+          .queryParam("page", "0")
+          .build()
+      }
+      .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__SEARCH__RO")))
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .returnResult(ErrorResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .hasStatus(HttpStatus.BAD_REQUEST.value())
+      .hasUserMessage("searchByPrison.page must be greater than or equal to 1")
+  }
+
+  @Test
+  fun `should return bad request given request with pageSize less than 1`() {
+    // Given
+
+    // When
+    val response = webTestClient.get()
+      .uri { uriBuilder ->
+        uriBuilder
+          .path(DefaultUriBuilderFactory().expand(URI_TEMPLATE, PRISON_ID).path)
+          .queryParam("pageSize", "0")
+          .build()
+      }
+      .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__SEARCH__RO")))
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .returnResult(ErrorResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .hasStatus(HttpStatus.BAD_REQUEST.value())
+      .hasUserMessage("searchByPrison.pageSize must be greater than or equal to 1")
+  }
+
+  @Test
+  fun `should return bad request given request with both page and pageSize less than 1`() {
+    // Given
+
+    // When
+    val response = webTestClient.get()
+      .uri { uriBuilder ->
+        uriBuilder
+          .path(DefaultUriBuilderFactory().expand(URI_TEMPLATE, PRISON_ID).path)
+          .queryParam("page", "0")
+          .queryParam("pageSize", "0")
+          .build()
+      }
+      .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__SEARCH__RO")))
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .returnResult(ErrorResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .hasStatus(HttpStatus.BAD_REQUEST.value())
+      .hasUserMessageContaining("searchByPrison.pageSize must be greater than or equal to 1")
+      .hasUserMessageContaining("searchByPrison.page must be greater than or equal to 1")
+  }
 }


### PR DESCRIPTION
PR to implement query string validation on the Search API (specifically `page` and `pageSize` are not less than 1)

Strictly speaking the validation was already there, and did work. What didn't work (well enough for my liking 😁 ) was the resultant error message in the error response body (it didn't describe the field that was in error, or what was wrong with it. It was just a plain old 400 response, with no useful content for the consumer)

This PR fixes this by adding the `@Validated` annotation to the controller method (that was the main issue), and then improving the exception handler for `ConstraintViolation` so that it uses the field name in the error response body if the violated constraint relates to a named field (some constraints can be applied to the method itself so therefore do not have a field or parameter name that is useful in the error response)

Finally, finished it off with a couple of integration tests to prove the fix 😁 👍 