### PR TITLE
added additional fields for has challenges/strengths

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ALNScreenerEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ALNScreenerEntity.kt
@@ -25,6 +25,12 @@ data class ALNScreenerEntity(
   @Column
   var updatedAtPrison: String,
 
+  @Column(name = "hasChallenges", nullable = false)
+  var hasChallenges: Boolean = false,
+
+  @Column(name = "hasStrengths", nullable = false)
+  var hasStrengths: Boolean = false,
+
   @OneToMany(mappedBy = "alnScreenerId", fetch = FetchType.EAGER)
   val challenges: MutableList<ChallengeEntity> = mutableListOf(),
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/ALNScreenerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/ALNScreenerService.kt
@@ -21,10 +21,13 @@ class ALNScreenerService(
           createdAtPrison = prisonId,
           updatedAtPrison = prisonId,
           screeningDate = screenerDate,
+          hasChallenges = challenges.isNotEmpty(),
+          hasStrengths = strengths.isNotEmpty(),
         ),
       )
       challengeService.createAlnChallenges(prisonNumber, challenges, prisonId, alnScreener.id)
       strengthService.createAlnStrengths(prisonNumber, strengths, prisonId, alnScreener.id)
+      alnScreenerRepository.saveAndFlush(alnScreener)
     }
   }
 }

--- a/src/main/resources/db/migration/common/V2025.07.22.0001__ALN_screener_updates.sql
+++ b/src/main/resources/db/migration/common/V2025.07.22.0001__ALN_screener_updates.sql
@@ -1,0 +1,20 @@
+
+ALTER TABLE aln_screener
+    ADD COLUMN "has_challenges" BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN "has_strengths" BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE aln_screener a
+SET has_challenges = EXISTS (
+    SELECT 1 FROM challenge c
+    WHERE c.aln_screener_id = a.id
+);
+
+UPDATE aln_screener a
+SET has_strengths = EXISTS (
+    SELECT 1 FROM strength s
+    WHERE s.aln_screener_id = a.id
+);
+
+ALTER TABLE aln_screener
+    ALTER COLUMN "has_challenges" DROP DEFAULT,
+    ALTER COLUMN "has_strengths" DROP DEFAULT;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/CreateALNScreenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/CreateALNScreenerTest.kt
@@ -39,6 +39,8 @@ class CreateALNScreenerTest : IntegrationTestBase() {
     assertThat(alnScreenerEntity).isNotNull
     assertThat(alnScreenerEntity!!.needsIdentified).isTrue()
     assertThat(alnScreenerEntity.screeningDate).isEqualTo(LocalDate.parse("2020-01-01"))
+    assertThat(alnScreenerEntity.hasStrengths).isTrue()
+    assertThat(alnScreenerEntity.hasChallenges).isTrue()
 
     val savedChallenges = alnScreenerEntity.challenges
     assertThat(savedChallenges.size).isEqualTo(2)
@@ -92,6 +94,8 @@ class CreateALNScreenerTest : IntegrationTestBase() {
     val alnScreenerEntity = alnScreenerRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber)
     assertThat(alnScreenerEntity).isNotNull
     assertThat(alnScreenerEntity!!.needsIdentified).isFalse()
+    assertThat(alnScreenerEntity.hasStrengths).isFalse()
+    assertThat(alnScreenerEntity.hasChallenges).isFalse()
     assertThat(alnScreenerEntity.screeningDate).isEqualTo(LocalDate.parse("2020-01-01"))
 
     val savedChallenges = alnScreenerEntity.challenges


### PR DESCRIPTION
Rather than rely on the absence of challenges of strengths to tell us there were none - added an explicit field to record that there were none. 