### PR TITLE
fix to date parsing issue

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/messaging/InboundEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/messaging/InboundEvent.kt
@@ -2,14 +2,12 @@ package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging
 
 import com.fasterxml.jackson.databind.JsonNode
 import java.net.URL
-import java.time.Instant
 
 data class InboundEvent(
   val eventType: EventType,
   val personReference: PersonReference,
   val additionalInformation: JsonNode,
-  val occurredAt: Instant,
-  val publishedAt: Instant,
+  val occurredAt: String,
   val description: String,
   val detailUrl: URL?,
   val version: String,


### PR DESCRIPTION
Sometimes the occurredAt date is an Instant and sometimes it's a LocalDateTime. This causes parsing issues in SAN API. 

Also we don't use occurredAt - so we could remove it but I feel like we might need it - or at least log it somewhere. So I've downgraded it to be a String. This is what other projects have done too. 

Definitely one to revisit at some time. 