### PR TITLE
process aln screener trigger

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/client/curious/ALNAssessmentDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/client/curious/ALNAssessmentDTO.kt
@@ -1,11 +1,14 @@
 package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.client.curious
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.time.LocalDate
 
 data class ALNAssessmentDTO(
   @JsonProperty("v2")
   val data: ALNData?,
 ) {
+  @get:JsonIgnore
   val alnAssessments: List<ALNAssessment>?
     get() = data?.assessments?.aln
 }
@@ -20,7 +23,7 @@ data class Assessments(
 )
 
 data class ALNAssessment(
-  val assessmentDate: String?,
+  val assessmentDate: LocalDate?,
   val assessmentOutcome: String?,
   val establishmentId: String?,
   val establishmentName: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/client/curious/CuriousApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/client/curious/CuriousApiClient.kt
@@ -68,7 +68,7 @@ class CuriousApiClient(
    */
   fun getALNAssessment(prisonNumber: String): ALNAssessmentDTO = try {
     curiousApiWebClient.get()
-      .uri("/learnerEducation/{prisonNumber}", prisonNumber)
+      .uri("/learnerAssessments/v2/{prisonNumber}", prisonNumber)
       .headers {
         it.contentType = MediaType.APPLICATION_JSON
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/AlnAssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/AlnAssessmentEntity.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.Table
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDate
 import java.util.UUID
 
 /**
@@ -21,6 +22,9 @@ data class AlnAssessmentEntity(
 
   @Column(nullable = false)
   val hasNeed: Boolean = false,
+
+  @Column(nullable = false)
+  var screeningDate: LocalDate,
 
   /**
    * This is the message reference we will receive when curious send us this information.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/resource/TestDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/resource/TestDataController.kt
@@ -60,7 +60,7 @@ class TestDataController(
     with(request) {
       educationService.recordEducationRecord(prisonNumber, inEducation, curiousRef)
       if (alnNeed) {
-        needService.recordAlnScreenerNeed(prisonNumber, true, curiousRef)
+        needService.recordAlnScreenerNeed(prisonNumber, true, curiousRef, LocalDate.now())
       }
       if (lddNeed) {
         needService.recordLddScreenerNeed(prisonNumber, true, curiousRef)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/NeedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/NeedService.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.ChallengeRepository
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.ConditionRepository
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.LddAssessmentRepository
+import java.time.LocalDate
 import java.util.*
 private val log = KotlinLogging.logger {}
 
@@ -27,12 +28,13 @@ class NeedService(
    *
    */
   @Transactional
-  fun recordAlnScreenerNeed(prisonNumber: String, hasNeed: Boolean, curiousReference: UUID) {
+  fun recordAlnScreenerNeed(prisonNumber: String, hasNeed: Boolean, curiousReference: UUID, screenerDate: LocalDate) {
     alnAssessmentRepository.save(
       AlnAssessmentEntity(
         hasNeed = hasNeed,
         prisonNumber = prisonNumber,
         curiousReference = curiousReference,
+        screeningDate = screenerDate,
       ),
     )
   }

--- a/src/main/resources/db/migration/common/V2025.07.30.0001__Add_screener_date_to_ALN_assessment.sql
+++ b/src/main/resources/db/migration/common/V2025.07.30.0001__Add_screener_date_to_ALN_assessment.sql
@@ -1,0 +1,10 @@
+ALTER TABLE aln_assessment
+    ADD COLUMN screening_date DATE;
+
+UPDATE aln_assessment
+SET screening_date = '2025-01-01';  --the only ones in the database are from test data harness
+
+ALTER TABLE aln_assessment
+    ALTER COLUMN screening_date SET NOT NULL;
+
+

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/common/AdditionalInformationBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/common/AdditionalInformationBuilder.kt
@@ -1,10 +1,12 @@
 package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.common
 
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.AdditionalInformation.EducationALNAssessmentUpdateAdditionalInformation
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.AdditionalInformation.PrisonerMergedAdditionalInformation
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.AdditionalInformation.PrisonerMergedAdditionalInformation.Reason
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.AdditionalInformation.PrisonerReceivedAdditionalInformation
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.randomValidPrisonNumber
+import java.util.*
 
 fun aValidPrisonerReceivedAdditionalInformation(
   prisonNumber: String = randomValidPrisonNumber(),
@@ -50,4 +52,8 @@ fun aValidPrisonerMergedAdditionalInformation(
   nomsNumber = prisonNumber,
   reason = reason,
   removedNomsNumber = removedNomsNumber,
+)
+
+fun aValidEducationALNAssessmentUpdateAdditionalInformation(curiousReference: UUID): EducationALNAssessmentUpdateAdditionalInformation = EducationALNAssessmentUpdateAdditionalInformation(
+  curiousExternalReference = curiousReference,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/IntegrationTestBase.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.Plan
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleStatus
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ReviewScheduleEntity
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ReviewScheduleStatus
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.AlnAssessmentRepository
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.AlnScreenerRepository
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.ChallengeRepository
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.ConditionRepository
@@ -46,6 +47,7 @@ import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.wiremo
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.wiremock.ManageUsersApiExtension.Companion.manageUsersApi
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.SqsMessage
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.service.EducationSupportPlanService
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.service.NeedService
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.MissingQueueException
 import uk.gov.justice.hmpps.test.kotlin.auth.JwtAuthorisationHelper
@@ -57,7 +59,7 @@ import java.util.concurrent.TimeUnit.SECONDS
 @ExtendWith(HmppsAuthApiExtension::class, HmppsPrisonerSearchApiExtension::class, CuriousApiExtension::class, ManageUsersApiExtension::class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
-@AutoConfigureWebTestClient(timeout = "PT5M")
+@AutoConfigureWebTestClient(timeout = "PT15M")
 abstract class IntegrationTestBase {
 
   companion object {
@@ -107,6 +109,9 @@ abstract class IntegrationTestBase {
   protected lateinit var alnScreenerRepository: AlnScreenerRepository
 
   @Autowired
+  protected lateinit var alnAssessmentRepository: AlnAssessmentRepository
+
+  @Autowired
   protected lateinit var conditionRepository: ConditionRepository
 
   @Autowired
@@ -123,6 +128,9 @@ abstract class IntegrationTestBase {
 
   @Autowired
   protected lateinit var elspPlanService: EducationSupportPlanService
+
+  @Autowired
+  protected lateinit var needService: NeedService
 
   @Autowired
   protected lateinit var jwtAuthHelper: JwtAuthorisationHelper
@@ -169,6 +177,8 @@ abstract class IntegrationTestBase {
   protected fun stubGetUserRepeatPass(username: String) = manageUsersApi.setUpManageUsersRepeatPass(username)
 
   protected fun stubGetUserRepeatFail(username: String) = manageUsersApi.setUpManageUsersRepeatFail(username)
+
+  protected fun stubGetCurious2LearnerAssessments(prisonId: String, response: String) = curiousApi.stubGetCurious2LearnerAssessments(prisonId, response)
 
   fun clearQueues() {
     // clear all the queues just in case there are any messages hanging around

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/messaging/CuriousALNTriggerEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/messaging/CuriousALNTriggerEventTest.kt
@@ -1,0 +1,108 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.messaging
+
+import org.assertj.core.api.Assertions
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilCallTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Isolated
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.common.aValidEducationALNAssessmentUpdateAdditionalInformation
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.common.aValidHmppsDomainEventsSqsMessage
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.EventType
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.SqsMessage
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.randomValidPrisonNumber
+import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
+import java.time.LocalDate
+import java.util.*
+
+@Isolated
+class CuriousALNTriggerEventTest : IntegrationTestBase() {
+
+  @Test
+  fun `should process Curious ALN domain event and mark the person as having an ALN need`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+    stubGetTokenFromHmppsAuth()
+    stubGetCurious2LearnerAssessments(prisonNumber, createTestALNAssessment(prisonNumber))
+    // When
+    val curiousReference = UUID.randomUUID()
+    val sqsMessage = aValidHmppsDomainEventsSqsMessage(
+      prisonNumber = prisonNumber,
+      eventType = EventType.EDUCATION_ALN_ASSESSMENT_UPDATE,
+      additionalInformation = aValidEducationALNAssessmentUpdateAdditionalInformation(curiousReference),
+      description = "ASSESSMENT_COMPLETED",
+    )
+    sendCuriousALNMessage(sqsMessage)
+
+    // Then
+    // wait until the queue is drained / message is processed
+    await untilCallTo {
+      domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+    } matches { it == 0 }
+    await untilCallTo {
+      val alnAssessment = alnAssessmentRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber)
+      Assertions.assertThat(alnAssessment!!.hasNeed).isTrue()
+      Assertions.assertThat(alnAssessment.curiousReference).isEqualTo(curiousReference)
+      Assertions.assertThat(alnAssessment.screeningDate).isEqualTo(LocalDate.of(2025, 1, 28))
+    } matches { it != null }
+
+    Assertions.assertThat(needService.hasALNScreenerNeed(prisonNumber)).isTrue()
+    Assertions.assertThat(needService.hasNeed(prisonNumber)).isTrue()
+  }
+
+  @Test
+  fun `should process Curious ALN domain event and mark the person as NOT having an ALN need`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+    stubGetTokenFromHmppsAuth()
+    stubGetCurious2LearnerAssessments(prisonNumber, createTestALNAssessment(prisonNumber = prisonNumber, hasNeed = false))
+    // When
+    val curiousReference = UUID.randomUUID()
+    val sqsMessage = aValidHmppsDomainEventsSqsMessage(
+      prisonNumber = prisonNumber,
+      eventType = EventType.EDUCATION_ALN_ASSESSMENT_UPDATE,
+      additionalInformation = aValidEducationALNAssessmentUpdateAdditionalInformation(curiousReference),
+      description = "ASSESSMENT_COMPLETED",
+    )
+    sendCuriousALNMessage(sqsMessage)
+
+    // Then
+    // wait until the queue is drained / message is processed
+    await untilCallTo {
+      domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+    } matches { it == 0 }
+
+    await untilCallTo {
+      val alnAssessment = alnAssessmentRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber)
+      Assertions.assertThat(alnAssessment!!.hasNeed).isFalse()
+      Assertions.assertThat(alnAssessment.curiousReference).isEqualTo(curiousReference)
+      Assertions.assertThat(alnAssessment.screeningDate).isEqualTo(LocalDate.of(2025, 1, 28))
+    } matches { it != null }
+
+    Assertions.assertThat(needService.hasALNScreenerNeed(prisonNumber)).isFalse()
+    Assertions.assertThat(needService.hasNeed(prisonNumber)).isFalse()
+  }
+
+  fun createTestALNAssessment(prisonNumber: String, hasNeed: Boolean = true): String = """{
+  "v2": {
+    "assessments": {
+      "aln": [
+        {
+          "assessmentDate": "2025-01-28",
+          "assessmentOutcome": "${if (hasNeed) "Yes" else "No"}",
+          "establishmentId": "123",
+          "establishmentName": "WTI",
+          "hasPrisonerConsent": "Yes",
+          "stakeholderReferral": "yes"
+        }
+      ]
+    },
+    "prn": "$prisonNumber"
+  }
+}"""
+
+  private fun sendCuriousALNMessage(sqsMessage: SqsMessage) {
+    sendDomainEvent(sqsMessage)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/wiremock/CuriousApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/wiremock/CuriousApiMockServer.kt
@@ -7,11 +7,14 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder.responseDefinition
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching
+import mu.KotlinLogging
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.client.curious.LearnerNeurodivergenceDTO
+
+private val log = KotlinLogging.logger {}
 
 class CuriousApiExtension :
   BeforeAllCallback,
@@ -63,6 +66,19 @@ class CuriousApiMockServer : WireMockServer(WIREMOCK_PORT) {
           responseDefinition()
             .withStatus(404)
             .withHeader("Content-Type", "application/json"),
+        ),
+    )
+  }
+
+  fun stubGetCurious2LearnerAssessments(prisonNumber: String, response: String) {
+    log.debug("setting up learner assessments stub for $prisonNumber")
+    stubFor(
+      get(urlPathMatching("/learnerAssessments/v2/$prisonNumber"))
+        .willReturn(
+          responseDefinition()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(response),
         ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/NeedServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/NeedServiceTest.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.ConditionRepository
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.LddAssessmentRepository
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.randomValidPrisonNumber
+import java.time.LocalDate
 import java.util.UUID
 
 @ExtendWith(MockitoExtension::class)
@@ -49,7 +50,7 @@ class NeedServiceTest {
     val prisonNumber = randomValidPrisonNumber()
     val hasNeed = true
 
-    needService.recordAlnScreenerNeed(prisonNumber, hasNeed, curiousRef)
+    needService.recordAlnScreenerNeed(prisonNumber, hasNeed, curiousRef, LocalDate.now())
 
     verify(alnAssessmentRepository).save(
       any<AlnAssessmentEntity>(),
@@ -73,7 +74,7 @@ class NeedServiceTest {
   fun `hasALNScreenerNeed returns true if latest ALN assessment has need`() {
     val prisonNumber = randomValidPrisonNumber()
     whenever(alnAssessmentRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber))
-      .thenReturn(AlnAssessmentEntity(prisonNumber = prisonNumber, hasNeed = true, curiousReference = curiousRef))
+      .thenReturn(AlnAssessmentEntity(prisonNumber = prisonNumber, hasNeed = true, curiousReference = curiousRef, screeningDate = LocalDate.now()))
 
     assertTrue(needService.hasALNScreenerNeed(prisonNumber))
   }


### PR DESCRIPTION
This is a bit of a courtesy commit as there is still a fair bit todo/think about.

In this PR I'm processing the inbound `prison.education-aln-assessment.updated` domain event and creating a record within SAN that reflects this. I've added tests that show the message processing and also the impact on the 'need' status of the person. 

There are a few TODOs - like outbound message processing to MN - for instance if a person goes from having a need to not then the plan creation/review schedule needs to be EXEMPTED. There are a million different combinations of this though and I need to be careful of how to manage them. 

Plus the older LDD screener was something that was going to be readonly until yesterday but now it seems we may be about to receive updates for these. Which is a shame as I've called this aln-assessment but in all likelihood it will process both LDD and ALN since they come from the same endpoint and domain message. Good thing there isn't a fast approaching deadline or anything. 

