### PR TITLE
implemented prisoner search API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/client/bankholidays/BankHolidaysApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/client/bankholidays/BankHolidaysApiClient.kt
@@ -18,9 +18,13 @@ class BankHolidaysApiClient(
 ) {
 
   @Cacheable(BANK_HOLIDAYS)
-  fun getBankHolidays(): BankHolidays = bankHolidaysApiWebClient.get()
-    .uri("/bank-holidays.json")
-    .retrieve()
-    .bodyToMono(BankHolidays::class.java)
-    .block()!!
+  fun getBankHolidays(): BankHolidays = try {
+    bankHolidaysApiWebClient.get()
+      .uri("/bank-holidays.json")
+      .retrieve()
+      .bodyToMono(BankHolidays::class.java)
+      .block()!!
+  } catch (e: Exception) {
+    throw Exception("Error retrieving bank holiday info ${e.cause}", e)
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/PrisonerOverviewEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/PrisonerOverviewEntity.kt
@@ -1,4 +1,5 @@
 package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity
+
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
@@ -9,29 +10,29 @@ import java.time.LocalDate
 @Entity
 @Immutable
 @Table(name = "prisoner_overview")
-data class PrisonerOverview(
+data class PrisonerOverviewEntity(
 
   @Id
   @Column(name = "prison_number")
   val prisonNumber: String,
 
   @Column(name = "has_aln_need")
-  val hasAlnNeed: Boolean? = null,
+  val hasAlnNeed: Boolean = false,
 
   @Column(name = "has_ldd_need")
-  val hasLddNeed: Boolean? = null,
+  val hasLddNeed: Boolean = false,
 
   @Column(name = "in_education")
-  val inEducation: Boolean? = null,
+  val inEducation: Boolean = false,
 
   @Column(name = "has_condition")
-  val hasCondition: Boolean? = null,
+  val hasCondition: Boolean = false,
 
   @Column(name = "has_non_screener_challenge")
-  val hasNonScreenerChallenge: Boolean? = null,
+  val hasNonScreenerChallenge: Boolean = false,
 
   @Column(name = "has_non_screener_strength")
-  val hasNonScreenerStrength: Boolean? = null,
+  val hasNonScreenerStrength: Boolean = false,
 
   @Column(name = "plan_creation_deadline_date")
   val planCreationDeadlineDate: LocalDate? = null,
@@ -43,11 +44,11 @@ data class PrisonerOverview(
   val deadlineDate: LocalDate? = null,
 
   @Column(name = "has_plan")
-  val hasPlan: Boolean? = null,
+  val hasPlan: Boolean = false,
 
   @Column(name = "plan_declined")
-  val planDeclined: Boolean? = null,
+  val planDeclined: Boolean = false,
 
   @Column(name = "has_need")
-  val hasNeed: Boolean? = null,
+  val hasNeed: Boolean = false,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/repository/PrisonerOverviewRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/repository/PrisonerOverviewRepository.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PrisonerOverviewEntity
+
+@Repository
+interface PrisonerOverviewRepository : JpaRepository<PrisonerOverviewEntity, String> {
+  fun findByPrisonNumberIn(prisonNumbers: List<String>): List<PrisonerOverviewEntity>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/SearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/SearchService.kt
@@ -1,60 +1,142 @@
 package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.service
 
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.client.prisonersearch.Prisoner
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PrisonerOverviewEntity
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.PrisonerOverviewRepository
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.mapper.SentenceTypeMapper
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.Person
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.PlanStatus
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.SearchSortDirection
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.SearchSortField
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.service.workingday.WorkingDayService
+import java.time.LocalDate
 
 @Service
-class SearchService(private val prisonerSearchApiService: PrisonerSearchApiService) {
+class SearchService(
+  private val prisonerSearchApiService: PrisonerSearchApiService,
+  private val prisonerOverviewRepository: PrisonerOverviewRepository,
+  private val workingDayService: WorkingDayService,
+) {
   fun searchPrisoners(searchCriteria: SearchCriteria): List<Person> {
-    val filteredAndSortedPrisoners = prisonerSearchApiService.getAllPrisonersInPrison(searchCriteria.prisonId)
+    // Get all prisoners in the prison
+    val prisonerSearchPrisoners = prisonerSearchApiService.getAllPrisonersInPrison(searchCriteria.prisonId)
+
+    // Get all prisonNumbers from filtered list
+    val prisonNumbers = prisonerSearchPrisoners.map { it.prisonerNumber }
+
+    // Fetch overview data in chunks to avoid query length issues
+    val prisonerOverviewResults = prisonNumbers.chunked(500).flatMap {
+      prisonerOverviewRepository.findByPrisonNumberIn(it)
+    }.associateBy { it.prisonNumber }
+
+    // Map the final results
+    val persons = prisonerSearchPrisoners.map { prisoner ->
+      val overview = prisonerOverviewResults[prisoner.prisonerNumber]
+      Person(
+        forename = prisoner.firstName,
+        surname = prisoner.lastName,
+        prisonNumber = prisoner.prisonerNumber,
+        dateOfBirth = prisoner.dateOfBirth,
+        releaseDate = prisoner.releaseDate,
+        cellLocation = prisoner.cellLocation,
+        sentenceType = SentenceTypeMapper.fromPrisonerSearchApiToModel(prisoner.legalStatus),
+        inEducation = overview?.inEducation ?: false,
+        hasAdditionalNeed = overview?.hasNeed ?: false,
+        deadlineDate = overview?.deadlineDate,
+        planStatus = determinePlanStatus(overview),
+      )
+    }
+
+    // Filter and sort them according to the search criteria
+    return persons
       .filterByCriteria(searchCriteria)
       .sortBy(searchCriteria)
+  }
 
-    // TODO - get Additional Needs data for each prisoner from this service DB
+  fun determinePlanStatus(overview: PrisonerOverviewEntity?): PlanStatus {
+    val today = LocalDate.now()
+    val todayPlus5WorkingDays = plus5WorkingDays()
 
-    return filteredAndSortedPrisoners.map {
-      Person(
-        forename = it.firstName,
-        surname = it.lastName,
-        prisonNumber = it.prisonerNumber,
-        dateOfBirth = it.dateOfBirth,
-        releaseDate = it.releaseDate,
-        cellLocation = it.cellLocation,
-        sentenceType = SentenceTypeMapper.fromPrisonerSearchApiToModel(it.legalStatus),
-        inEducation = false,
-        hasAdditionalNeed = false,
-        planStatus = PlanStatus.NO_PLAN,
-      )
+    return when {
+      // No overview record at all
+      overview == null -> PlanStatus.NO_PLAN
+
+      // No need, no education, and no plan = no plan required
+      !overview.inEducation && !overview.hasNeed && !overview.hasPlan -> PlanStatus.NO_PLAN
+
+      // Explicitly declined
+      overview.planDeclined -> PlanStatus.PLAN_DECLINED
+
+      // Overdue review
+      overview.reviewDeadlineDate != null &&
+        overview.deadlineDate != null &&
+        overview.deadlineDate == overview.reviewDeadlineDate &&
+        overview.reviewDeadlineDate < today -> PlanStatus.REVIEW_OVERDUE
+
+      // Overdue plan creation
+      overview.planCreationDeadlineDate != null &&
+        overview.deadlineDate != null &&
+        overview.deadlineDate == overview.planCreationDeadlineDate &&
+        overview.planCreationDeadlineDate < today -> PlanStatus.PLAN_OVERDUE
+
+      // Needs plan (has needs and education, no deadline, and no plan yet)
+      !overview.hasPlan &&
+        overview.deadlineDate == null &&
+        overview.hasNeed &&
+        overview.inEducation -> PlanStatus.NEEDS_PLAN
+
+      // Review due soon (within 5 working days)
+      overview.reviewDeadlineDate != null &&
+        overview.deadlineDate != null &&
+        overview.deadlineDate == overview.reviewDeadlineDate &&
+        !overview.reviewDeadlineDate.isBefore(today) &&
+        !overview.reviewDeadlineDate.isAfter(todayPlus5WorkingDays) -> PlanStatus.REVIEW_DUE
+
+      // Plan is due soon (within 5 working days)
+      overview.planCreationDeadlineDate != null &&
+        overview.deadlineDate != null &&
+        overview.deadlineDate == overview.planCreationDeadlineDate &&
+        !overview.hasPlan &&
+        !overview.planDeclined &&
+        !overview.planCreationDeadlineDate.isBefore(today) &&
+        !overview.planCreationDeadlineDate.isAfter(todayPlus5WorkingDays) -> PlanStatus.PLAN_DUE
+
+      // Has a plan but is effectively inactive
+      overview.hasPlan && (!overview.inEducation || !overview.hasNeed) -> PlanStatus.INACTIVE_PLAN
+
+      // Has a plan and is active
+      overview.hasPlan -> PlanStatus.ACTIVE_PLAN
+
+      // Fallback
+      else -> PlanStatus.NO_PLAN
     }
   }
 
-  private fun List<Prisoner>.filterByCriteria(searchCriteria: SearchCriteria): List<Prisoner> = this.filter { prisoner ->
-    // Filter by prisoner name or number
-    (
-      searchCriteria.prisonerNameOrNumber.isNullOrBlank() ||
-        prisoner.firstName.contains(searchCriteria.prisonerNameOrNumber, ignoreCase = true) ||
-        prisoner.lastName.contains(searchCriteria.prisonerNameOrNumber, ignoreCase = true) ||
-        prisoner.prisonerNumber.equals(searchCriteria.prisonerNameOrNumber, ignoreCase = true)
-      )
+  fun plus5WorkingDays(): LocalDate = workingDayService.getNextWorkingDayNDaysFromToday(5)
+}
+
+private fun List<Person>.filterByCriteria(searchCriteria: SearchCriteria): List<Person> = this.filter { prisoner ->
+  // Filter by prisoner name or number
+  (
+    searchCriteria.prisonerNameOrNumber.isNullOrBlank() ||
+      prisoner.forename.contains(searchCriteria.prisonerNameOrNumber, ignoreCase = true) ||
+      prisoner.surname.contains(searchCriteria.prisonerNameOrNumber, ignoreCase = true) ||
+      prisoner.prisonNumber.equals(searchCriteria.prisonerNameOrNumber, ignoreCase = true)
+    )
+}
+
+private fun List<Person>.sortBy(searchCriteria: SearchCriteria): List<Person> {
+  val comparator: Comparator<Person> = when (searchCriteria.sortBy) {
+    SearchSortField.PRISONER_NAME -> compareBy(nullsLast()) { it.surname }
+    SearchSortField.PRISON_NUMBER -> compareBy(nullsLast()) { it.prisonNumber }
+    SearchSortField.RELEASE_DATE -> compareBy(nullsLast()) { it.releaseDate }
+    SearchSortField.CELL_LOCATION -> compareBy(nullsLast()) { it.cellLocation }
+    SearchSortField.DEADLINE_DATE -> compareBy(nullsLast()) { it.deadlineDate }
   }
 
-  private fun List<Prisoner>.sortBy(searchCriteria: SearchCriteria): List<Prisoner> {
-    val comparator: Comparator<Prisoner> = when (searchCriteria.sortBy) {
-      SearchSortField.PRISONER_NAME -> compareBy(nullsLast()) { it.lastName }
-      SearchSortField.PRISON_NUMBER -> compareBy(nullsLast()) { it.prisonerNumber }
-      SearchSortField.RELEASE_DATE -> compareBy(nullsLast()) { it.releaseDate }
-      SearchSortField.CELL_LOCATION -> compareBy(nullsLast()) { it.cellLocation }
-    }
-
-    return when (searchCriteria.sortDirection) {
-      SearchSortDirection.ASC -> this.sortedWith(comparator)
-      SearchSortDirection.DESC -> this.sortedWith(comparator.reversed())
-    }
+  return when (searchCriteria.sortDirection) {
+    SearchSortDirection.ASC -> this.sortedWith(comparator)
+    SearchSortDirection.DESC -> this.sortedWith(comparator.reversed())
   }
 }
 

--- a/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
+++ b/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.1.1
 info:
   title: Support For Additional Needs API
-  version: '0.9.0'
+  version: '0.9.2'
   description: Support For Additional Needs API
   contact:
     name: Learning and Work Progress team
@@ -669,6 +669,7 @@ components:
         - PRISON_NUMBER
         - CELL_LOCATION
         - RELEASE_DATE
+        - DEADLINE_DATE
 
     SearchSortDirection:
       type: string
@@ -874,6 +875,11 @@ components:
         planStatus:
           $ref: '#/components/schemas/PlanStatus'
           description: The status of the persons plan.
+        deadlineDate:
+          type: string
+          format: date
+          description: Either the plan creation,or review deadline date.
+          example: "2035-11-01"
 
       required:
         - forename

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/IntegrationTestBase.kt
@@ -37,6 +37,8 @@ import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.container.LocalStackContainer
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.container.LocalStackContainer.setLocalStackProperties
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.container.PostgresContainer
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.wiremock.BankHolidaysApiExtension
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.wiremock.BankHolidaysApiExtension.Companion.bankHolidaysApi
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.wiremock.CuriousApiExtension
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.wiremock.CuriousApiExtension.Companion.curiousApi
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.wiremock.HmppsAuthApiExtension
@@ -56,7 +58,7 @@ import java.util.*
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.util.concurrent.TimeUnit.SECONDS
 
-@ExtendWith(HmppsAuthApiExtension::class, HmppsPrisonerSearchApiExtension::class, CuriousApiExtension::class, ManageUsersApiExtension::class)
+@ExtendWith(HmppsAuthApiExtension::class, HmppsPrisonerSearchApiExtension::class, CuriousApiExtension::class, ManageUsersApiExtension::class, BankHolidaysApiExtension::class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
 @AutoConfigureWebTestClient(timeout = "PT15M")
@@ -179,6 +181,8 @@ abstract class IntegrationTestBase {
   protected fun stubGetUserRepeatFail(username: String) = manageUsersApi.setUpManageUsersRepeatFail(username)
 
   protected fun stubGetCurious2LearnerAssessments(prisonId: String, response: String) = curiousApi.stubGetCurious2LearnerAssessments(prisonId, response)
+
+  protected fun stubForBankHoliday() = bankHolidaysApi.stubBankHolidays()
 
   fun clearQueues() {
     // clear all the queues just in case there are any messages hanging around

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/SearchByPrisonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/SearchByPrisonTest.kt
@@ -28,6 +28,7 @@ class SearchByPrisonTest : IntegrationTestBase() {
     // Given
     stubGetTokenFromHmppsAuth()
     stubGetPrisonersInPrisonFromPrisonerSearchApi(PRISON_ID, PRISONERS_IN_PRISON)
+    stubForBankHoliday()
 
     // When
     val response = webTestClient.get()
@@ -73,6 +74,7 @@ class SearchByPrisonTest : IntegrationTestBase() {
         ]
       }
     """.trimIndent()
+    stubForBankHoliday()
     stubGetPrisonersInPrisonFromPrisonerSearchApi(PRISON_ID, apiResponse)
 
     // When

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/wiremock/BankHolidaysApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/wiremock/BankHolidaysApiMockServer.kt
@@ -1,0 +1,524 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.wiremock
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder.responseDefinition
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+class BankHolidaysApiExtension :
+  BeforeAllCallback,
+  AfterAllCallback,
+  BeforeEachCallback {
+
+  companion object {
+    @JvmField
+    val bankHolidaysApi = BankHolidaysApiMockServer()
+  }
+
+  override fun beforeAll(context: ExtensionContext) {
+    bankHolidaysApi.start()
+  }
+
+  override fun beforeEach(context: ExtensionContext) {
+    bankHolidaysApi.resetRequests()
+  }
+
+  override fun afterAll(context: ExtensionContext) {
+    bankHolidaysApi.stop()
+  }
+}
+
+class BankHolidaysApiMockServer : WireMockServer(WIREMOCK_PORT) {
+  companion object {
+    private const val WIREMOCK_PORT = 9096
+    private val objectMapper = ObjectMapper()
+      .registerModule(JavaTimeModule())
+      .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+  }
+
+  fun stubBankHolidays() {
+    stubFor(
+      get(urlPathMatching("/bank-holidays.json"))
+        .willReturn(
+          responseDefinition()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              """{
+  "england-and-wales": {
+    "division": "england-and-wales",
+    "events": [
+      {
+        "title": "New Year’s Day",
+        "date": "2019-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2019-04-19",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2019-04-22",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2019-05-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2019-05-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2019-08-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2019-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2019-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2020-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2020-04-10",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2020-04-13",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday (VE day)",
+        "date": "2020-05-08",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2020-05-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2020-08-31",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2020-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2020-12-28",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2021-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2021-04-02",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2021-04-05",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2021-05-03",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2021-05-31",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2021-08-30",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2021-12-27",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2021-12-28",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2022-01-03",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2022-04-15",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2022-04-18",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2022-05-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2022-06-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Platinum Jubilee bank holiday",
+        "date": "2022-06-03",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2022-08-29",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Bank Holiday for the State Funeral of Queen Elizabeth II",
+        "date": "2022-09-19",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2022-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2022-12-27",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2023-01-02",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2023-04-07",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2023-04-10",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2023-05-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Bank holiday for the coronation of King Charles III",
+        "date": "2023-05-08",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2023-05-29",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2023-08-28",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2023-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2023-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2024-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2024-03-29",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2024-04-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2024-05-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2024-05-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2024-08-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2024-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2024-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2025-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2025-04-18",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2025-04-21",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2025-05-05",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2025-05-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2025-08-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2025-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2025-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2026-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2026-04-03",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2026-04-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2026-05-04",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2026-05-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2026-08-31",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2026-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2026-12-28",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2027-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2027-03-26",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2027-03-29",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2027-05-03",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2027-05-31",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2027-08-30",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2027-12-27",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2027-12-28",
+        "notes": "Substitute day",
+        "bunting": true
+      }
+    ]
+  },
+  "scotland": {
+    "division": "scotland",
+    "events": []
+  },
+  "northern-ireland": {
+    "division": "northern-ireland",
+    "events": []
+  }
+}
+              """.trimIndent(),
+            ),
+        ),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/SearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/SearchServiceTest.kt
@@ -13,17 +13,25 @@ import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.client.prisonersearch.Prisoner
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.client.prisonersearch.aValidPrisoner
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.PrisonerOverviewRepository
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.mapper.SentenceTypeMapper
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.Person
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.PlanStatus
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.SearchSortDirection
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.SearchSortField
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.service.workingday.WorkingDayService
 import java.time.LocalDate
 
 @ExtendWith(MockitoExtension::class)
 class SearchServiceTest {
   @Mock
   private lateinit var prisonerSearchApiService: PrisonerSearchApiService
+
+  @Mock
+  private lateinit var prisonerOverviewRepository: PrisonerOverviewRepository
+
+  @Mock
+  private lateinit var workingDayService: WorkingDayService
 
   @InjectMocks
   private lateinit var service: SearchService


### PR DESCRIPTION
This was fun!

Basically using the previously created view to marry up prisoners in SAN with the prisoners from prisoner search. 

Then assigning a plan status to each result using this logic: 


Status | Definition
-- | --
Needs plan | The prisoner's has an additional need and is currently in education, but has no plan or deadline to create a plan (i.e. the need was identified after enrolment in a course).  They can create an ELSP but will not have a due date.
Plan due | The prisoner’s had an additional need and no existing ELSP at the point of joining education. They have an ELSP due within 5 working days of enrolment into Education.
Review due | The prisoner has an ELSP created, and they have a review due within 5 working days.
Active plan | The prisoner has an ELSP created, but they don’t have a review due within 5 working days.
Plan overdue | The prisoner has a need identified and is also enrolled in education, they have gone past the due date for the creation of the ELSP.
Review overdue | The prisoner has an ELSP, and they have gone past the due date for their review.
Inactive plan | The prisoner has an additional need and was in education, so had an ELSP created. They are currently either no longer in education or do not have a need identified anymore.
Plan declined | The prisoner has refused creation of the ELSP, so has no due date.
No | The prisoner has never had an ELSP, and currently does not have an additional need and is not in education.

Also makes use of the working days service.

Then implementing sorting on the results - only new sort is DEADLINE_DATE

No tests have been harmed in the making of this PR. I'm going to do some manual testing in dev to verify the above logic, then write some tests. 