### PR TITLE
additional plan status sorting

### DIFF
--- a/docs/trigger-specs/CuriousTriggers.yaml
+++ b/docs/trigger-specs/CuriousTriggers.yaml
@@ -29,7 +29,7 @@ paths:
                   type: string
                   enum:
                     - EDUCATION_STARTED
-                    - ALL_EDUCATION_STOPPED
+                    - EDUCATION_STOPPED
                   example: EDUCATION_STARTED
                 detailUrl:
                   type: string

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/SearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/SearchService.kt
@@ -125,13 +125,26 @@ private fun List<Person>.filterByCriteria(searchCriteria: SearchCriteria): List<
     )
 }
 
+val customPlanStatusOrder = listOf(
+  PlanStatus.NEEDS_PLAN,
+  PlanStatus.PLAN_DUE,
+  PlanStatus.REVIEW_DUE,
+  PlanStatus.ACTIVE_PLAN,
+  PlanStatus.PLAN_OVERDUE,
+  PlanStatus.REVIEW_OVERDUE,
+  PlanStatus.INACTIVE_PLAN,
+  PlanStatus.PLAN_DECLINED,
+  PlanStatus.NO_PLAN,
+).withIndex().associate { it.value to it.index }
+
 private fun List<Person>.sortBy(searchCriteria: SearchCriteria): List<Person> {
   val comparator: Comparator<Person> = when (searchCriteria.sortBy) {
-    SearchSortField.PRISONER_NAME -> compareBy(nullsLast()) { it.surname }
-    SearchSortField.PRISON_NUMBER -> compareBy(nullsLast()) { it.prisonNumber }
+    SearchSortField.PRISONER_NAME -> compareBy { it.surname }
+    SearchSortField.PRISON_NUMBER -> compareBy { it.prisonNumber }
     SearchSortField.RELEASE_DATE -> compareBy(nullsLast()) { it.releaseDate }
     SearchSortField.CELL_LOCATION -> compareBy(nullsLast()) { it.cellLocation }
     SearchSortField.DEADLINE_DATE -> compareBy(nullsLast()) { it.deadlineDate }
+    SearchSortField.PLAN_STATUS -> compareBy { person -> customPlanStatusOrder[person.planStatus] }
   }
 
   return when (searchCriteria.sortDirection) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,9 +5,6 @@ info.app:
 spring:
   application:
     name: hmpps-support-additional-needs-api
-  codec:
-    max-in-memory-size: 10MB
-
   jackson:
     date-format: "yyyy-MM-dd HH:mm:ss"
     serialization:
@@ -72,6 +69,9 @@ spring:
     password: ${spring.datasource.password}
     validateMigrationNaming: true
     locations: classpath:/db/migration/common,classpath:/db/migration/prod,classpath:/db/postgres/common,classpath:/db/postgres/prod
+  http:
+    codecs:
+      max-in-memory-size: 10MB
 
 server:
   port: 8080

--- a/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
+++ b/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.1.1
 info:
   title: Support For Additional Needs API
-  version: '0.9.2'
+  version: '0.9.3'
   description: Support For Additional Needs API
   contact:
     name: Learning and Work Progress team
@@ -670,6 +670,7 @@ components:
         - CELL_LOCATION
         - RELEASE_DATE
         - DEADLINE_DATE
+        - PLAN_STATUS
 
     SearchSortDirection:
       type: string

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/SearchSanResultsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/SearchSanResultsTest.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.Integr
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.PlanStatus
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.SearchByPrisonResponse
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.service.customPlanStatusOrder
 import java.time.LocalDate
 
 class SearchSanResultsTest : IntegrationTestBase() {
@@ -124,5 +125,10 @@ class SearchSanResultsTest : IntegrationTestBase() {
 
     val prisoner9PlanStatus = body.people.first { it.prisonNumber == PRISONER_9.prisonerNumber }.planStatus
     assertEquals(PlanStatus.NO_PLAN, prisoner9PlanStatus)
+
+    val expectedOrder = body.people.sortedBy { customPlanStatusOrder[it.planStatus] }.map { it.prisonNumber }
+    val actualOrder = body.people.map { it.prisonNumber }
+
+    assertEquals(expectedOrder, actualOrder, "Results are not ordered by custom planStatus order")
   }
 }


### PR DESCRIPTION
Sorting for plan status - This is a configurable sort. They are currently in this order: 


Needs plan
Plan due
Review due
Active plan
Plan overdue
Review overdue
Inactive plan
Plan declined
No plan

But obviously this can be changed to any order by reordering the customPlanStatusOrder. Also this hasn't been asked for in the ticket anyway but I feel it will be at some point. 

