### PR TITLE
Update to ALN LDD need logic

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/PrisonerOverviewEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/PrisonerOverviewEntity.kt
@@ -17,10 +17,10 @@ data class PrisonerOverviewEntity(
   val prisonNumber: String,
 
   @Column(name = "has_aln_need")
-  val hasAlnNeed: Boolean = false,
+  val hasAlnNeed: Boolean?,
 
   @Column(name = "has_ldd_need")
-  val hasLddNeed: Boolean = false,
+  val hasLddNeed: Boolean?,
 
   @Column(name = "in_education")
   val inEducation: Boolean = false,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/ALNScreenerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/ALNScreenerService.kt
@@ -74,8 +74,6 @@ class ALNScreenerService(
       screenerDate = latestAssessment.assessmentDate!!,
     )
 
-    // TODO may also use this to process LDD need since the same endpoint gives both sets of information.
-
     // TODO Now update the plan creation schedule or the plan review schedule
     // if there is a schedule and now there is no need - EXEMPT due to NO_NEED
     // if there is no schedule AND the person is in EDUCATION create a new plan creation schedule OR

--- a/src/main/resources/db/migration/common/V2025.08.06.0001__Prisoner_overview_4.sql
+++ b/src/main/resources/db/migration/common/V2025.08.06.0001__Prisoner_overview_4.sql
@@ -1,0 +1,141 @@
+DROP VIEW prisoner_overview;
+
+CREATE OR REPLACE VIEW prisoner_overview AS
+WITH all_prisoners AS (
+    SELECT prison_number FROM aln_assessment
+    UNION
+    SELECT prison_number FROM ldd_assessment
+    UNION
+    SELECT prison_number FROM education
+    UNION
+    SELECT prison_number FROM condition
+    UNION
+    SELECT prison_number FROM challenge
+    UNION
+    SELECT prison_number FROM strength
+    UNION
+    SELECT prison_number FROM plan_creation_schedule
+    UNION
+    SELECT prison_number FROM review_schedule
+    UNION
+    SELECT prison_number FROM elsp_plan
+)
+SELECT
+    ap.prison_number,
+
+    -- Latest ALN assessment
+    aln.has_need AS has_aln_need,
+
+    -- Latest LDD assessment
+    ldd.has_need AS has_ldd_need,
+
+    -- Latest education record
+    COALESCE(edu.in_education, false) AS in_education,
+
+    -- Any active condition
+    COALESCE(cond.exists IS NOT NULL, false) AS has_condition,
+
+    -- Any active non-screener challenge
+    COALESCE(chal.exists IS NOT NULL, false) AS has_non_screener_challenge,
+
+    -- Any active non-screener strength
+    COALESCE(str.exists IS NOT NULL, false) AS has_non_screener_strength,
+
+    -- Plan creation deadline
+    pcs.deadline_date AS plan_creation_deadline_date,
+
+    -- Latest scheduled review deadline
+    rsched.deadline_date AS review_deadline_date,
+
+    -- Combined deadline (review > plan creation > null)
+    COALESCE(rsched.deadline_date, pcs.deadline_date) AS deadline_date,
+
+    -- Has a plan in elsp_plan
+    COALESCE(plan.exists IS NOT NULL, false) AS has_plan,
+
+    -- Plan declined if status is EXEMPT_PRISONER_NOT_COMPLY
+    COALESCE(pcs.status = 'EXEMPT_PRISONER_NOT_COMPLY', false) AS plan_declined,
+
+    -- has need flag
+    CASE
+        WHEN aln.has_need IS NOT NULL THEN aln.has_need
+        WHEN ldd.has_need IS NOT NULL THEN ldd.has_need
+        ELSE FALSE
+    END
+        OR COALESCE(cond.exists IS NOT NULL, false)
+        OR COALESCE(chal.exists IS NOT NULL, false)
+    AS has_need
+
+FROM all_prisoners ap
+
+-- Latest ALN assessment
+         LEFT JOIN LATERAL (
+    SELECT has_need
+    FROM aln_assessment
+    WHERE prison_number = ap.prison_number
+    ORDER BY created_at DESC
+    LIMIT 1
+    ) aln ON true
+
+-- Latest LDD assessment
+         LEFT JOIN LATERAL (
+    SELECT has_need
+    FROM ldd_assessment
+    WHERE prison_number = ap.prison_number
+    ORDER BY created_at DESC
+    LIMIT 1
+    ) ldd ON true
+
+-- Latest education record
+         LEFT JOIN LATERAL (
+    SELECT in_education
+    FROM education
+    WHERE prison_number = ap.prison_number
+    ORDER BY created_at DESC
+    LIMIT 1
+    ) edu ON true
+
+-- Any active condition
+         LEFT JOIN LATERAL (
+    SELECT 1 AS exists
+    FROM condition
+    WHERE prison_number = ap.prison_number AND active = true
+    LIMIT 1
+    ) cond ON true
+
+-- Any active non-screener challenge
+         LEFT JOIN LATERAL (
+    SELECT 1 AS exists
+    FROM challenge
+    WHERE prison_number = ap.prison_number AND active = true AND aln_screener_id IS NULL
+    LIMIT 1
+    ) chal ON true
+
+-- Any active non-screener strength
+         LEFT JOIN LATERAL (
+    SELECT 1 AS exists
+    FROM strength
+    WHERE prison_number = ap.prison_number AND active = true AND aln_screener_id IS NULL
+    LIMIT 1
+    ) str ON true
+
+-- Plan creation deadline (and status)
+         LEFT JOIN plan_creation_schedule pcs
+                   ON pcs.prison_number = ap.prison_number
+
+-- Latest scheduled review deadline
+         LEFT JOIN LATERAL (
+    SELECT deadline_date
+    FROM review_schedule
+    WHERE prison_number = ap.prison_number AND status = 'SCHEDULED'
+    ORDER BY deadline_date DESC
+    LIMIT 1
+    ) rsched ON true
+
+-- Existence of a plan
+         LEFT JOIN LATERAL (
+    SELECT 1 AS exists
+    FROM elsp_plan
+    WHERE prison_number = ap.prison_number
+    LIMIT 1
+    ) plan ON true;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/NeedServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/NeedServiceTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.service
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNull
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
@@ -76,7 +77,7 @@ class NeedServiceTest {
     whenever(alnAssessmentRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber))
       .thenReturn(AlnAssessmentEntity(prisonNumber = prisonNumber, hasNeed = true, curiousReference = curiousRef, screeningDate = LocalDate.now()))
 
-    assertTrue(needService.hasALNScreenerNeed(prisonNumber))
+    assertTrue(needService.hasALNScreenerNeed(prisonNumber) == true)
   }
 
   @Test
@@ -85,7 +86,7 @@ class NeedServiceTest {
     whenever(alnAssessmentRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber))
       .thenReturn(null)
 
-    assertFalse(needService.hasALNScreenerNeed(prisonNumber))
+    assertNull(needService.hasALNScreenerNeed(prisonNumber))
   }
 
   @Test
@@ -94,7 +95,7 @@ class NeedServiceTest {
     whenever(lddAssessmentRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber))
       .thenReturn(LddAssessmentEntity(prisonNumber = prisonNumber, hasNeed = true))
 
-    assertTrue(needService.hasLDDNeed(prisonNumber))
+    assertTrue(needService.hasLDDNeed(prisonNumber) == true)
   }
 
   @Test
@@ -103,7 +104,7 @@ class NeedServiceTest {
     whenever(lddAssessmentRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber))
       .thenReturn(null)
 
-    assertFalse(needService.hasLDDNeed(prisonNumber))
+    assertNull(needService.hasLDDNeed(prisonNumber))
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/NeedServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/NeedServiceTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.Chal
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ConditionEntity
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.Domain
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.LddAssessmentEntity
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.NeedSource
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ReferenceDataEntity
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ReferenceDataKey
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.Source
@@ -75,7 +76,14 @@ class NeedServiceTest {
   fun `hasALNScreenerNeed returns true if latest ALN assessment has need`() {
     val prisonNumber = randomValidPrisonNumber()
     whenever(alnAssessmentRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber))
-      .thenReturn(AlnAssessmentEntity(prisonNumber = prisonNumber, hasNeed = true, curiousReference = curiousRef, screeningDate = LocalDate.now()))
+      .thenReturn(
+        AlnAssessmentEntity(
+          prisonNumber = prisonNumber,
+          hasNeed = true,
+          curiousReference = curiousRef,
+          screeningDate = LocalDate.now(),
+        ),
+      )
 
     assertTrue(needService.hasALNScreenerNeed(prisonNumber) == true)
   }
@@ -176,9 +184,16 @@ class NeedServiceTest {
   fun `hasNeed returns true if ALN assessment has need and ignores LDD`() {
     val prisonNumber = randomValidPrisonNumber()
 
-    // ALN returns true → should short-circuit and ignore LDD
+    // ALN returns true
     whenever(alnAssessmentRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber))
-      .thenReturn(AlnAssessmentEntity(prisonNumber = prisonNumber, hasNeed = true, curiousReference = curiousRef, screeningDate = LocalDate.now()))
+      .thenReturn(
+        AlnAssessmentEntity(
+          prisonNumber = prisonNumber,
+          hasNeed = true,
+          curiousReference = curiousRef,
+          screeningDate = LocalDate.now(),
+        ),
+      )
 
     // No active SAN needs
     whenever(challengeRepository.findAllByPrisonNumber(prisonNumber)).thenReturn(emptyList())
@@ -193,7 +208,14 @@ class NeedServiceTest {
 
     // ALN returns true
     whenever(alnAssessmentRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber))
-      .thenReturn(AlnAssessmentEntity(prisonNumber = prisonNumber, hasNeed = false, curiousReference = curiousRef, screeningDate = LocalDate.now()))
+      .thenReturn(
+        AlnAssessmentEntity(
+          prisonNumber = prisonNumber,
+          hasNeed = false,
+          curiousReference = curiousRef,
+          screeningDate = LocalDate.now(),
+        ),
+      )
 
     // No active SAN needs
     whenever(challengeRepository.findAllByPrisonNumber(prisonNumber)).thenReturn(emptyList())
@@ -206,11 +228,11 @@ class NeedServiceTest {
   fun `hasNeed returns true if ALN assessment is null has has LDD with need`() {
     val prisonNumber = randomValidPrisonNumber()
 
-    // ALN returns true → should short-circuit and ignore LDD
+    // ALN returns null
     whenever(alnAssessmentRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber))
       .thenReturn(null)
 
-    // LDD returns false, but it should not be checked or affect outcome
+    // LDD returns true,
     whenever(lddAssessmentRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber))
       .thenReturn(LddAssessmentEntity(prisonNumber = prisonNumber, hasNeed = true))
 
@@ -221,7 +243,98 @@ class NeedServiceTest {
     assertTrue(needService.hasNeed(prisonNumber))
   }
 
-  private fun getChallengeEntity(prisonNumber: String, active: Boolean = true, alnScreener: Boolean = true): ChallengeEntity = ChallengeEntity(
+  @Test
+  fun `getNeedSources returns ALN_SCREENER when ALN has need`() {
+    val prisonNumber = randomValidPrisonNumber()
+
+    whenever(alnAssessmentRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber))
+      .thenReturn(AlnAssessmentEntity(prisonNumber, true, LocalDate.now(), curiousRef))
+    whenever(challengeRepository.findAllByPrisonNumber(prisonNumber)).thenReturn(emptyList())
+    whenever(conditionRepository.findAllByPrisonNumber(prisonNumber)).thenReturn(emptyList())
+
+    val result = needService.getNeedSources(prisonNumber)
+    assertTrue(result.contains(NeedSource.ALN_SCREENER))
+    assertFalse(result.contains(NeedSource.LDD_SCREENER))
+  }
+
+  @Test
+  fun `getNeedSources returns LDD_SCREENER when ALN is null and LDD has need`() {
+    val prisonNumber = randomValidPrisonNumber()
+
+    whenever(alnAssessmentRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber))
+      .thenReturn(null)
+    whenever(lddAssessmentRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber))
+      .thenReturn(LddAssessmentEntity(prisonNumber, true))
+    whenever(challengeRepository.findAllByPrisonNumber(prisonNumber)).thenReturn(emptyList())
+    whenever(conditionRepository.findAllByPrisonNumber(prisonNumber)).thenReturn(emptyList())
+
+    val result = needService.getNeedSources(prisonNumber)
+    assertTrue(result.contains(NeedSource.LDD_SCREENER))
+    assertFalse(result.contains(NeedSource.ALN_SCREENER))
+  }
+
+  @Test
+  fun `getNeedSources returns CHALLENGE_NOT_ALN_SCREENER when active non-screener challenge exists`() {
+    val prisonNumber = randomValidPrisonNumber()
+
+    whenever(alnAssessmentRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber))
+      .thenReturn(null)
+    whenever(lddAssessmentRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber))
+      .thenReturn(null)
+    whenever(challengeRepository.findAllByPrisonNumber(prisonNumber))
+      .thenReturn(listOf(getChallengeEntity(prisonNumber, active = true, alnScreener = false)))
+    whenever(conditionRepository.findAllByPrisonNumber(prisonNumber)).thenReturn(emptyList())
+
+    val result = needService.getNeedSources(prisonNumber)
+    assertTrue(result.contains(NeedSource.CHALLENGE_NOT_ALN_SCREENER))
+  }
+
+  @Test
+  fun `getNeedSources returns CONDITION_CONFIRMED_DIAGNOSIS when active confirmed diagnosis condition exists`() {
+    val prisonNumber = randomValidPrisonNumber()
+
+    whenever(alnAssessmentRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber)).thenReturn(null)
+    whenever(lddAssessmentRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber)).thenReturn(null)
+    whenever(challengeRepository.findAllByPrisonNumber(prisonNumber)).thenReturn(emptyList())
+    whenever(conditionRepository.findAllByPrisonNumber(prisonNumber))
+      .thenReturn(listOf(getConditionEntity(prisonNumber, active = true).copy(source = Source.CONFIRMED_DIAGNOSIS)))
+
+    val result = needService.getNeedSources(prisonNumber)
+    assertTrue(result.contains(NeedSource.CONDITION_CONFIRMED_DIAGNOSIS))
+  }
+
+  @Test
+  fun `getNeedSources returns CONDITION_SELF_DECLARED when active self-declared condition exists`() {
+    val prisonNumber = randomValidPrisonNumber()
+
+    whenever(alnAssessmentRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber)).thenReturn(null)
+    whenever(lddAssessmentRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber)).thenReturn(null)
+    whenever(challengeRepository.findAllByPrisonNumber(prisonNumber)).thenReturn(emptyList())
+    whenever(conditionRepository.findAllByPrisonNumber(prisonNumber))
+      .thenReturn(listOf(getConditionEntity(prisonNumber, active = true).copy(source = Source.SELF_DECLARED)))
+
+    val result = needService.getNeedSources(prisonNumber)
+    assertTrue(result.contains(NeedSource.CONDITION_SELF_DECLARED))
+  }
+
+  @Test
+  fun `getNeedSources returns empty set when no sources are present`() {
+    val prisonNumber = randomValidPrisonNumber()
+
+    whenever(alnAssessmentRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber)).thenReturn(null)
+    whenever(lddAssessmentRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber)).thenReturn(null)
+    whenever(challengeRepository.findAllByPrisonNumber(prisonNumber)).thenReturn(emptyList())
+    whenever(conditionRepository.findAllByPrisonNumber(prisonNumber)).thenReturn(emptyList())
+
+    val result = needService.getNeedSources(prisonNumber)
+    assertTrue(result.isEmpty())
+  }
+
+  private fun getChallengeEntity(
+    prisonNumber: String,
+    active: Boolean = true,
+    alnScreener: Boolean = true,
+  ): ChallengeEntity = ChallengeEntity(
     prisonNumber = prisonNumber,
     challengeType = getChallengeType(),
     createdAtPrison = "BXI",


### PR DESCRIPTION
Following some discussions with the stakeholders. The ALN screener takes priority over the LDD screener. 

That is to say 
if there is no ALN screener and LDD has a need then the has need = true
if there is an ALN screener and it doesn't identify a need AND they have an LDD that DOES identify a need the has need = false since the presence of an ALN screener renders the LDD screener mute. 

Oh and if an LDD screener is carried out after 1/10/2025 in a lot10 prison - we will ignore it. I've removed the TODO in the code. 