### PR TITLE
Small change to ALN screener query

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/repository/AlnScreenerRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/repository/AlnScreenerRepository.kt
@@ -7,5 +7,5 @@ import java.util.UUID
 
 @Repository
 interface AlnScreenerRepository : JpaRepository<ALNScreenerEntity, UUID> {
-  fun findFirstByPrisonNumberOrderByScreeningDateDesc(prisonNumber: String): ALNScreenerEntity?
+  fun findFirstByPrisonNumberOrderByScreeningDateDescCreatedAtDesc(prisonNumber: String): ALNScreenerEntity?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/ChallengeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/ChallengeService.kt
@@ -32,7 +32,7 @@ class ChallengeService(
       .findAllByPrisonNumberAndAlnScreenerIdIsNull(prisonNumber)
 
     val alnScreener = alnScreenerRepository
-      .findFirstByPrisonNumberOrderByScreeningDateDesc(prisonNumber)
+      .findFirstByPrisonNumberOrderByScreeningDateDescCreatedAtDesc(prisonNumber)
 
     val alnChallenges = alnScreener
       ?.challenges

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/StrengthService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/StrengthService.kt
@@ -32,7 +32,7 @@ class StrengthService(
       .findAllByPrisonNumberAndAlnScreenerIdIsNull(prisonNumber)
 
     val alnScreener = alnScreenerRepository
-      .findFirstByPrisonNumberOrderByScreeningDateDesc(prisonNumber)
+      .findFirstByPrisonNumberOrderByScreeningDateDescCreatedAtDesc(prisonNumber)
 
     val alnStrengths = alnScreener?.strengths
       .orEmpty()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/CreateALNScreenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/CreateALNScreenerTest.kt
@@ -35,7 +35,7 @@ class CreateALNScreenerTest : IntegrationTestBase() {
 
     // Then
 
-    val alnScreenerEntity = alnScreenerRepository.findFirstByPrisonNumberOrderByScreeningDateDesc(prisonNumber)
+    val alnScreenerEntity = alnScreenerRepository.findFirstByPrisonNumberOrderByScreeningDateDescCreatedAtDesc(prisonNumber)
     assertThat(alnScreenerEntity).isNotNull
     assertThat(alnScreenerEntity!!.needsIdentified).isTrue()
     assertThat(alnScreenerEntity.screeningDate).isEqualTo(LocalDate.parse("2020-01-01"))
@@ -91,7 +91,7 @@ class CreateALNScreenerTest : IntegrationTestBase() {
       .isCreated
 
     // Then
-    val alnScreenerEntity = alnScreenerRepository.findFirstByPrisonNumberOrderByScreeningDateDesc(prisonNumber)
+    val alnScreenerEntity = alnScreenerRepository.findFirstByPrisonNumberOrderByScreeningDateDescCreatedAtDesc(prisonNumber)
     assertThat(alnScreenerEntity).isNotNull
     assertThat(alnScreenerEntity!!.needsIdentified).isFalse()
     assertThat(alnScreenerEntity.hasStrengths).isFalse()


### PR DESCRIPTION
Since it is possible to enter two ALN screeners in the same day the previous query would have produced spurious results. Added additional clause to also order on the created timestamp. So if there were two on the same date it would return the most recent of those. 

You can't just sort on the created timestamp since the screener date is a manually entered date and can (probably will always) be a date in the past. 