### PR TITLE
introducing earliest start date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/PlanCreationScheduleEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/PlanCreationScheduleEntity.kt
@@ -36,6 +36,9 @@ data class PlanCreationScheduleEntity(
   @Column
   var deadlineDate: LocalDate?,
 
+  @Column(name = "earliest_start_date")
+  var earliestStartDate: LocalDate?,
+
   @Column
   @Enumerated(value = EnumType.STRING)
   var status: PlanCreationScheduleStatus,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/PlanCreationScheduleHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/PlanCreationScheduleHistoryEntity.kt
@@ -33,6 +33,9 @@ data class PlanCreationScheduleHistoryEntity(
   @Column(name = "deadline_date")
   val deadlineDate: LocalDate?,
 
+  @Column(name = "earliest_start_date")
+  val earliestStartDate: LocalDate?,
+
   @Column
   @Enumerated(value = EnumType.STRING)
   val status: PlanCreationScheduleStatus,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ReviewScheduleEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ReviewScheduleEntity.kt
@@ -28,7 +28,7 @@ data class ReviewScheduleEntity(
   val prisonNumber: String,
 
   @Column
-  var deadlineDate: LocalDate,
+  var deadlineDate: LocalDate? = null,
 
   @Column
   @Enumerated(value = EnumType.STRING)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ReviewScheduleHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ReviewScheduleHistoryEntity.kt
@@ -27,7 +27,7 @@ data class ReviewScheduleHistoryEntity(
   val prisonNumber: String,
 
   @Column(name = "deadline_date")
-  val deadlineDate: LocalDate,
+  val deadlineDate: LocalDate? = null,
 
   @Column
   @Enumerated(value = EnumType.STRING)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/mapper/PlanCreationScheduleHistoryMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/mapper/PlanCreationScheduleHistoryMapper.kt
@@ -45,6 +45,7 @@ class PlanCreationScheduleHistoryMapper(
     PlanCreationScheduleResponse(
       reference = reference,
       deadlineDate = deadlineDate,
+      earliestStartDate = earliestStartDate,
       status = toPlanCreationStatus(status),
       createdBy = createdBy,
       createdByDisplayName = userService.getUserDetails(createdBy).name,

--- a/src/main/resources/db/migration/common/V2025.08.08.0001__schedule_changes.sql
+++ b/src/main/resources/db/migration/common/V2025.08.08.0001__schedule_changes.sql
@@ -1,0 +1,12 @@
+ALTER TABLE review_schedule
+    ALTER COLUMN deadline_date DROP NOT NULL;
+
+ALTER TABLE review_schedule_history
+    ALTER COLUMN deadline_date DROP NOT NULL;
+
+
+ALTER TABLE plan_creation_schedule
+    ADD COLUMN earliest_start_date date NULL;
+
+ALTER TABLE plan_creation_schedule_history
+    ADD COLUMN earliest_start_date date NULL;

--- a/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
+++ b/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.1.1
 info:
   title: Support For Additional Needs API
-  version: '0.10.0'
+  version: '0.10.1'
   description: Support For Additional Needs API
   contact:
     name: Learning and Work Progress team
@@ -1196,7 +1196,14 @@ components:
           type: string
           format: date
           description: |
-            An ISO-8601 date representing date that the Review is due.
+            An ISO-8601 date representing date that the Review is due. This date can be null.
+            For example the person was in education and had a cataract which meant they had a visual support need. 
+            The ELSP was created for the person. At some point in the future the cataract was removed and 
+            so the plan was updated removing this need education ends for this person. 
+            Then the person is enrolled in education once again. After enrolling a new need is identified (say) 
+            ADHD then the plan will have a review schedule generated but because the person had already started 
+            education the deadline date will be blank and therefore the review is optional and not subject to 
+            the KPI requirements.
           example: '2023-11-19'
         reviewCompletedDate:
           type: string
@@ -1242,7 +1249,6 @@ components:
           description: the version number of this schedule (the highest number is the most recent version of this review schedule)
       required:
         - reference
-        - deadlineDate
         - status
 
     ConditionResponse:
@@ -1647,11 +1653,21 @@ components:
           format: uuid
           description: The unique reference of this plan creation schedule
           example: c88a6c48-97e2-4c04-93b5-98619966447b
+        earliestStartDate:
+          type: string
+          format: date
+          description: |
+            An ISO-8601 date representing earliest date that the plan can be created. 
+            If this date is null then there is no restriction. eg when a person has a need identified 
+            after they are enrolled in education.
+          example: '2023-11-19'
         deadlineDate:
           type: string
           format: date
           description: |
-            An ISO-8601 date representing date that the plan creation is due.
+            An ISO-8601 date representing date that the plan creation is due. 
+            If this date is null then there is no dead line date. eg when a person has a need identified 
+            after they are enrolled in education.
           example: '2023-11-19'
         planCompletedDate:
           type: string

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/IntegrationTestBase.kt
@@ -230,6 +230,7 @@ abstract class IntegrationTestBase {
         createdAtPrison = "BXI",
         updatedAtPrison = "BXI",
         needSources = setOf(NeedSource.ALN_SCREENER, NeedSource.CONDITION_SELF_DECLARED),
+        earliestStartDate = null,
       )
     planCreationScheduleRepository.saveAndFlush(planCreationScheduleEntity)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/PlanCreationScheduleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/PlanCreationScheduleServiceTest.kt
@@ -168,6 +168,7 @@ class PlanCreationScheduleServiceTest {
       updatedAtPrison = "N/A",
       version = 1,
       needSources = setOf(ALN_SCREENER),
+      earliestStartDate = null,
     ).apply {
       createdAt = Instant.now()
       updatedAt = Instant.now()
@@ -227,6 +228,7 @@ class PlanCreationScheduleServiceTest {
     deadlineDate = LocalDate.now(),
     createdAtPrison = "BXI",
     updatedAtPrison = "BXI",
+    earliestStartDate = null,
   )
 
   @Test


### PR DESCRIPTION
As identified recently the users are unable to start an ELSP until the person starts education. I have introduced the field earliestStartDate on the planCreationSchedule. 

The FE needs to check that today is equal to or greater than earliestStartDate before rendering the create plan link. 

Also in this PR there the review deadline date is optional. This is due to the edgiest of edge cases: 

In certain circumstances the review deadline date can be null. This is the case where someone has an old Education support plan but for whatever reason the need that the person had at the time has gone away.

For example the person was in education and had a cataract which meant they had a visual support need. The ELSP was created for the person. At some point in the future the cataract was removed and so the plan was updated removing this need education ends for this person. Then the person is enrolled in education once again. After enrolling a new need is identified (say) ADHD then the plan will have a review schedule generated but because the person had already started education the deadline date will be blank and therefore the review is optional and not subject to the KPI requirements.
