### PR TITLE
added trigger endpoints

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/TestDataService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/TestDataService.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.stereotype.Service
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.SqsMessage
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
+import uk.gov.justice.hmpps.sqs.MissingQueueException
+
+@Service
+class TestDataService(
+  private val objectMapper: ObjectMapper,
+  private val hmppsQueueService: HmppsQueueService,
+) {
+
+  val domainEventQueue by lazy {
+    hmppsQueueService.findByQueueId("supportadditionalneeds")
+      ?: throw MissingQueueException("HmppsQueue supportadditionalneeds not found")
+  }
+  val domainEventQueueClient by lazy { domainEventQueue.sqsClient }
+
+  fun sendDomainEvent(
+    message: SqsMessage,
+    queueUrl: String = domainEventQueue.queueUrl,
+  ): SendMessageResponse = domainEventQueueClient.sendMessage(
+    SendMessageRequest.builder()
+      .queueUrl(queueUrl)
+      .messageBody(
+        objectMapper.writeValueAsString(message),
+      ).build(),
+  ).get()
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/CreateTestSetupTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/CreateTestSetupTest.kt
@@ -1,16 +1,21 @@
 package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.resource
 
 import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilCallTo
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleEntity
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.TimelineEventType
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.randomValidPrisonNumber
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.EducationNeedRequest
-import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.assertThat
+import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
+import java.time.LocalDate
 
 class CreateTestSetupTest : IntegrationTestBase() {
   companion object {
-    private const val URI_TEMPLATE = "/profile/{prisonNumber}/set-up-data"
+    private const val URI_TEMPLATE = "/profile/{prisonNumber}"
   }
 
   @Test
@@ -24,7 +29,7 @@ class CreateTestSetupTest : IntegrationTestBase() {
 
     // When
     val response = webTestClient.post()
-      .uri(URI_TEMPLATE, prisonNumber)
+      .uri("$URI_TEMPLATE/set-up-data", prisonNumber)
       .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW"), username = "testuser"))
       .bodyValue(educationNeedRequest)
       .exchange()
@@ -35,6 +40,78 @@ class CreateTestSetupTest : IntegrationTestBase() {
     // Then
     val actual = response.responseBody.blockFirst()
     assertThat(actual).isNotNull()
+  }
+
+  @Test
+  fun `test ALN trigger`() {
+    // Given
+    stubGetTokenFromHmppsAuth()
+    stubGetDisplayName("testuser")
+    stubForBankHoliday()
+    val prisonNumber = randomValidPrisonNumber()
+    stubGetCurious2LearnerAssessments(prisonNumber, createTestALNAssessment(prisonNumber))
+
+    // When
+    webTestClient.post()
+      .uri("$URI_TEMPLATE/aln-trigger", prisonNumber)
+      .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW"), username = "testuser"))
+      .exchange()
+      .expectStatus()
+      .isCreated
+
+    // Then
+    // wait until the queue is drained / message is processed
+    await untilCallTo {
+      domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+    } matches { it == 0 }
+    await untilCallTo {
+      val alnAssessment = alnAssessmentRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber)
+      assertThat(alnAssessment!!.hasNeed).isTrue()
+      assertThat(alnAssessment.screeningDate).isEqualTo(LocalDate.of(2025, 1, 28))
+    } matches { it != null }
+
+    assertThat(needService.hasALNScreenerNeed(prisonNumber)).isTrue()
+    assertThat(needService.hasNeed(prisonNumber)).isTrue()
+
+    val timelineEntries = timelineRepository.findAllByPrisonNumberOrderByCreatedAt(prisonNumber)
+    assertThat(timelineEntries[0].event).isEqualTo(TimelineEventType.CURIOUS_ASSESSMENT_TRIGGER)
+    assertThat(timelineEntries[0].additionalInfo).contains("curiousReference:")
+  }
+
+  @Test
+  fun `test Education trigger`() {
+    // Given
+    stubGetTokenFromHmppsAuth()
+    stubGetDisplayName("testuser")
+    stubForBankHoliday()
+    val prisonNumber = randomValidPrisonNumber()
+    stubGetCurious2InEducation(prisonNumber, inEducationResponse(prisonNumber, "PES"))
+
+    // When
+    webTestClient.post()
+      .uri("$URI_TEMPLATE/education-trigger", prisonNumber)
+      .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW"), username = "testuser"))
+      .exchange()
+      .expectStatus()
+      .isCreated
+
+    // Then
+    // wait until the queue is drained / message is processed
+    await untilCallTo {
+      domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+    } matches { it == 0 }
+    await untilCallTo {
+      val education = educationRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber)
+      assertThat(education!!.inEducation).isTrue()
+    } matches { it != null }
+
+    // also check the education enrolment(s) have been saved
+    val enrolments = educationEnrolmentRepository.findAllByPrisonNumber(prisonNumber)
+    assertThat(enrolments).hasSize(1)
+    assertThat(enrolments[0].endDate).isNull()
+
+    val timelineEntries = timelineRepository.findAllByPrisonNumberOrderByCreatedAt(prisonNumber)
+    assertThat(timelineEntries[0].event).isEqualTo(TimelineEventType.CURIOUS_EDUCATION_TRIGGER)
   }
 
   private fun createEducationNeedRequest(): EducationNeedRequest = EducationNeedRequest(
@@ -49,3 +126,50 @@ class CreateTestSetupTest : IntegrationTestBase() {
     alnScreener = true,
   )
 }
+
+fun inEducationResponse(prisonNumber: String, fundingType: String = "PES"): String = """{
+    "v1": [],
+    "v2": [
+        {
+            "prn": "$prisonNumber",
+            "establishmentId": "CFI",
+            "establishmentName": "CARDIFF (HMP)",
+            "qualificationCode": "60322457",
+            "qualificationName": "Award in Cycle Maintenance",
+            "learningStartDate": "2025-10-02",
+            "learningPlannedEndDate": "2025-01-31",
+            "learnerOnRemand": null,
+            "isAccredited": true,
+            "aimType": null,
+            "fundingType": "$fundingType",
+            "deliveryApproach": null,
+            "deliveryLocationpostcode": null,
+            "completionStatus": "Continuing",
+            "learningActualEndDate": null,
+            "outcome": null,
+            "outcomeGrade": null,
+            "outcomeDate": null,
+            "withdrawalReason": null,
+            "withdrawalReasonAgreed": null,
+            "withdrawalReviewed": false
+        }
+    ]
+}"""
+
+fun createTestALNAssessment(prisonNumber: String, hasNeed: Boolean = true): String = """{
+  "v2": {
+    "assessments": {
+      "aln": [
+        {
+          "assessmentDate": "2025-01-28",
+          "assessmentOutcome": "${if (hasNeed) "Yes" else "No"}",
+          "establishmentId": "123",
+          "establishmentName": "WTI",
+          "hasPrisonerConsent": "Yes",
+          "stakeholderReferral": "yes"
+        }
+      ]
+    },
+    "prn": "$prisonNumber"
+  }
+}"""


### PR DESCRIPTION
As mentioned on the stand up this may be pointless but I'd already started it before I realised the problem. 

Two POST endpoints that simulate us receiving a message from MN: 

/profile/{prisonNumber}/aln-trigger
/profile/{prisonNumber}/education-trigger

they will create a message and pop it on our inbound queue. The existing ALN/education processing then takes over from this point. 

The reason why this may be pointless is that whichever prisonNumber that is used to trigger the aln/education also has to exist in Curious. We don't have any control over this and only have one or two examples of people we can test with. 

