### PR TITLE
check that the review history is recorded and retrievable

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspPlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspPlanEntity.kt
@@ -7,6 +7,7 @@ import jakarta.persistence.EntityListeners
 import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
+import org.hibernate.Hibernate
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.envers.Audited
@@ -20,7 +21,7 @@ import java.util.*
 @EntityListeners(value = [AuditingEntityListener::class])
 @Table(name = "elsp_plan")
 @Audited(withModifiedFlag = false)
-class ElspPlanEntity(
+data class ElspPlanEntity(
   @Column(updatable = false)
   val prisonNumber: String,
 
@@ -85,4 +86,16 @@ class ElspPlanEntity(
   @UpdateTimestamp
   @Column
   var updatedAt: Instant? = null,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as ElspPlanEntity
+
+    return id == other.id
+  }
+
+  override fun hashCode(): Int = javaClass.hashCode()
+
+  override fun toString(): String = this::class.simpleName + "(id = $id, prisonNumber = $prisonNumber)"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspPlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspPlanEntity.kt
@@ -21,7 +21,7 @@ import java.util.*
 @EntityListeners(value = [AuditingEntityListener::class])
 @Table(name = "elsp_plan")
 @Audited(withModifiedFlag = false)
-data class ElspPlanEntity(
+class ElspPlanEntity(
   @Column(updatable = false)
   val prisonNumber: String,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspPlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspPlanEntity.kt
@@ -4,7 +4,6 @@ import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
-import jakarta.persistence.FetchType
 import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
@@ -61,7 +60,7 @@ class ElspPlanEntity(
   @Column
   var updatedAtPrison: String,
 
-  @OneToMany(mappedBy = "elspPlan", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+  @OneToMany(mappedBy = "elspPlan", cascade = [CascadeType.ALL], orphanRemoval = true)
   val otherContributors: MutableList<OtherContributorEntity> = mutableListOf(),
 
   @Id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspPlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspPlanEntity.kt
@@ -61,7 +61,7 @@ class ElspPlanEntity(
   @Column
   var updatedAtPrison: String,
 
-  @OneToMany(mappedBy = "elspPlan", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
+  @OneToMany(mappedBy = "elspPlan", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
   val otherContributors: MutableList<OtherContributorEntity> = mutableListOf(),
 
   @Id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspPlanHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspPlanHistoryEntity.kt
@@ -4,7 +4,6 @@ import jakarta.persistence.Column
 import jakarta.persistence.Embeddable
 import jakarta.persistence.EmbeddedId
 import jakarta.persistence.Entity
-import jakarta.persistence.FetchType
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import org.hibernate.annotations.Immutable
@@ -24,7 +23,7 @@ class ElspPlanHistoryEntity(
   @Column(name = "plan_created_by_job_role")
   val planCreatedByJobRole: String? = null,
 
-  @OneToMany(mappedBy = "plan", fetch = FetchType.LAZY)
+  @OneToMany(mappedBy = "plan")
   val otherContributors: List<OtherContributorHistoryEntity> = emptyList(),
 
   @Column(name = "has_current_ehcp")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspPlanHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspPlanHistoryEntity.kt
@@ -4,6 +4,8 @@ import jakarta.persistence.Column
 import jakarta.persistence.Embeddable
 import jakarta.persistence.EmbeddedId
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import org.hibernate.annotations.Immutable
 import java.time.Instant
@@ -12,7 +14,7 @@ import java.util.*
 @Entity
 @Immutable
 @Table(name = "elsp_plan_history")
-data class ElspPlanHistoryEntity(
+class ElspPlanHistoryEntity(
   @Column(name = "prison_number")
   val prisonNumber: String,
 
@@ -21,6 +23,9 @@ data class ElspPlanHistoryEntity(
 
   @Column(name = "plan_created_by_job_role")
   val planCreatedByJobRole: String? = null,
+
+  @OneToMany(mappedBy = "plan", fetch = FetchType.LAZY)
+  val otherContributors: List<OtherContributorHistoryEntity> = emptyList(),
 
   @Column(name = "has_current_ehcp")
   val hasCurrentEhcp: Boolean = false,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspPlanHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspPlanHistoryEntity.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.EmbeddedId
 import jakarta.persistence.Entity
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
+import org.hibernate.Hibernate
 import org.hibernate.annotations.Immutable
 import java.time.Instant
 import java.util.*
@@ -13,7 +14,7 @@ import java.util.*
 @Entity
 @Immutable
 @Table(name = "elsp_plan_history")
-class ElspPlanHistoryEntity(
+data class ElspPlanHistoryEntity(
   @Column(name = "prison_number")
   val prisonNumber: String,
 
@@ -73,7 +74,19 @@ class ElspPlanHistoryEntity(
 
   @EmbeddedId
   val id: ElspPlanHistoryEntityKey,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as ElspPlanHistoryEntity
+
+    return id == other.id
+  }
+
+  override fun hashCode(): Int = javaClass.hashCode()
+
+  override fun toString(): String = this::class.simpleName + "(id = $id, prisonNumber = $prisonNumber)"
+}
 
 @Embeddable
 data class ElspPlanHistoryEntityKey(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspReviewEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspReviewEntity.kt
@@ -4,7 +4,6 @@ import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
-import jakarta.persistence.FetchType
 import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
@@ -46,7 +45,7 @@ class ElspReviewEntity(
   @Column
   var updatedAtPrison: String,
 
-  @OneToMany(mappedBy = "elspReview", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+  @OneToMany(mappedBy = "elspReview", cascade = [CascadeType.ALL], orphanRemoval = true)
   val otherContributors: MutableList<OtherReviewContributorEntity> = mutableListOf(),
 
   @Column(updatable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspReviewEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspReviewEntity.kt
@@ -7,6 +7,7 @@ import jakarta.persistence.EntityListeners
 import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
+import org.hibernate.Hibernate
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.envers.Audited
@@ -20,7 +21,7 @@ import java.util.*
 @EntityListeners(value = [AuditingEntityListener::class])
 @Table(name = "elsp_review")
 @Audited(withModifiedFlag = false)
-class ElspReviewEntity(
+data class ElspReviewEntity(
   @Column(updatable = false)
   val prisonNumber: String,
 
@@ -73,4 +74,16 @@ class ElspReviewEntity(
   @UpdateTimestamp
   @Column
   var updatedAt: Instant? = null,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as ElspReviewEntity
+
+    return id == other.id
+  }
+
+  override fun hashCode(): Int = javaClass.hashCode()
+
+  override fun toString(): String = this::class.simpleName + "(id = $id, prisonNumber = $prisonNumber)"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspReviewEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspReviewEntity.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity
 
-import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
@@ -21,7 +20,7 @@ import java.util.*
 @EntityListeners(value = [AuditingEntityListener::class])
 @Table(name = "elsp_review")
 @Audited(withModifiedFlag = false)
-data class ElspReviewEntity(
+class ElspReviewEntity(
   @Column(updatable = false)
   val prisonNumber: String,
 
@@ -46,7 +45,7 @@ data class ElspReviewEntity(
   @Column
   var updatedAtPrison: String,
 
-  @OneToMany(mappedBy = "elspReview", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
+  @OneToMany(mappedBy = "elspReview", fetch = FetchType.EAGER)
   val otherContributors: MutableList<OtherReviewContributorEntity> = mutableListOf(),
 
   @Column(updatable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspReviewEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspReviewEntity.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity
 
+import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
@@ -45,7 +46,7 @@ class ElspReviewEntity(
   @Column
   var updatedAtPrison: String,
 
-  @OneToMany(mappedBy = "elspReview", fetch = FetchType.EAGER)
+  @OneToMany(mappedBy = "elspReview", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
   val otherContributors: MutableList<OtherReviewContributorEntity> = mutableListOf(),
 
   @Column(updatable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspReviewHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspReviewHistoryEntity.kt
@@ -5,7 +5,6 @@ import jakarta.persistence.Embeddable
 import jakarta.persistence.EmbeddedId
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
-import jakarta.persistence.FetchType
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
@@ -34,7 +33,7 @@ class ElspReviewHistoryEntity(
   @Column(name = "reviewer_feedback")
   val reviewerFeedback: String? = null,
 
-  @OneToMany(mappedBy = "elspReview", fetch = FetchType.LAZY)
+  @OneToMany(mappedBy = "elspReview")
   val otherContributors: List<OtherReviewContributorHistoryEntity> = emptyList(),
 
   @Column(name = "review_schedule_reference", updatable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspReviewHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspReviewHistoryEntity.kt
@@ -1,0 +1,74 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.FetchType
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.Instant
+import java.util.*
+
+@Entity
+@EntityListeners(value = [AuditingEntityListener::class])
+@Table(name = "elsp_review_history")
+class ElspReviewHistoryEntity(
+  @Column(name = "prison_number", updatable = false)
+  val prisonNumber: String,
+
+  @Column(name = "review_created_by_name", length = 200)
+  val reviewCreatedByName: String? = null,
+
+  @Column(name = "review_created_by_job_role", length = 200)
+  val reviewCreatedByJobRole: String? = null,
+
+  @Column(name = "prisoner_declined_feedback", nullable = false)
+  val prisonerDeclinedFeedback: Boolean = false,
+
+  @Column(name = "prisoner_feedback")
+  val prisonerFeedback: String? = null,
+
+  @Column(name = "reviewer_feedback")
+  val reviewerFeedback: String? = null,
+
+  @OneToMany(mappedBy = "elspReview", fetch = FetchType.LAZY)
+  val otherContributors: List<OtherReviewContributorHistoryEntity> = emptyList(),
+
+  @Column(name = "review_schedule_reference", updatable = false)
+  val reviewScheduleReference: UUID,
+
+  @EmbeddedId
+  val id: ElspReviewHistoryEntityKey,
+
+  @Column(updatable = false)
+  val reference: UUID = UUID.randomUUID(),
+
+  @Column(name = "created_by")
+  val createdBy: String,
+
+  @Column(name = "created_at")
+  val createdAt: Instant,
+
+  @Column(name = "updated_by")
+  val updatedBy: String,
+
+  @Column(name = "updated_at")
+  val updatedAt: Instant,
+
+  @Column(name = "created_at_prison")
+  val createdAtPrison: String,
+
+  @Column(name = "updated_at_prison")
+  val updatedAtPrison: String,
+)
+
+@Embeddable
+data class ElspReviewHistoryEntityKey(
+  @Column(name = "rev_id")
+  val revisionNumber: Long,
+  @Column(name = "id")
+  val id: UUID,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspReviewHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspReviewHistoryEntity.kt
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
+import org.hibernate.Hibernate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.Instant
 import java.util.*
@@ -14,7 +15,7 @@ import java.util.*
 @Entity
 @EntityListeners(value = [AuditingEntityListener::class])
 @Table(name = "elsp_review_history")
-class ElspReviewHistoryEntity(
+data class ElspReviewHistoryEntity(
   @Column(name = "prison_number", updatable = false)
   val prisonNumber: String,
 
@@ -62,7 +63,19 @@ class ElspReviewHistoryEntity(
 
   @Column(name = "updated_at_prison")
   val updatedAtPrison: String,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as ElspReviewHistoryEntity
+
+    return id == other.id
+  }
+
+  override fun hashCode(): Int = javaClass.hashCode()
+
+  override fun toString(): String = this::class.simpleName + "(id = $id, prisonNumber = $prisonNumber)"
+}
 
 @Embeddable
 data class ElspReviewHistoryEntityKey(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/OtherContributorEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/OtherContributorEntity.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
@@ -23,8 +24,8 @@ import java.util.*
 @Audited(withModifiedFlag = false)
 data class OtherContributorEntity(
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "elsp_plan_id")
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "elsp_plan_id", nullable = false)
   var elspPlan: ElspPlanEntity,
 
   @Column(length = 200, nullable = false)
@@ -40,8 +41,9 @@ data class OtherContributorEntity(
   var updatedAtPrison: String,
 
   @Id
+  @GeneratedValue
   @Column
-  val id: UUID = UUID.randomUUID(),
+  var id: UUID? = null,
 
   @Column(updatable = false)
   val reference: UUID = UUID.randomUUID(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/OtherContributorEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/OtherContributorEntity.kt
@@ -3,8 +3,6 @@ package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
-import jakarta.persistence.FetchType
-import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
@@ -24,7 +22,7 @@ import java.util.*
 @Audited(withModifiedFlag = false)
 data class OtherContributorEntity(
 
-  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @ManyToOne(optional = false)
   @JoinColumn(name = "elsp_plan_id", nullable = false)
   var elspPlan: ElspPlanEntity,
 
@@ -41,9 +39,8 @@ data class OtherContributorEntity(
   var updatedAtPrison: String,
 
   @Id
-  @GeneratedValue
   @Column
-  var id: UUID? = null,
+  val id: UUID = UUID.randomUUID(),
 
   @Column(updatable = false)
   val reference: UUID = UUID.randomUUID(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/OtherReviewContributorEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/OtherReviewContributorEntity.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
@@ -23,8 +24,8 @@ import java.util.*
 @Audited(withModifiedFlag = false)
 class OtherReviewContributorEntity(
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "elsp_review_id")
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "elsp_review_id", nullable = false)
   var elspReview: ElspReviewEntity,
 
   @Column(length = 200, nullable = false)
@@ -40,8 +41,9 @@ class OtherReviewContributorEntity(
   var updatedAtPrison: String,
 
   @Id
+  @GeneratedValue
   @Column
-  val id: UUID = UUID.randomUUID(),
+  var id: UUID? = null,
 
   @Column(updatable = false)
   val reference: UUID = UUID.randomUUID(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/OtherReviewContributorEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/OtherReviewContributorEntity.kt
@@ -3,8 +3,6 @@ package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
-import jakarta.persistence.FetchType
-import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
@@ -24,7 +22,7 @@ import java.util.*
 @Audited(withModifiedFlag = false)
 class OtherReviewContributorEntity(
 
-  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @ManyToOne(optional = false)
   @JoinColumn(name = "elsp_review_id", nullable = false)
   var elspReview: ElspReviewEntity,
 
@@ -41,9 +39,8 @@ class OtherReviewContributorEntity(
   var updatedAtPrison: String,
 
   @Id
-  @GeneratedValue
   @Column
-  var id: UUID? = null,
+  val id: UUID = UUID.randomUUID(),
 
   @Column(updatable = false)
   val reference: UUID = UUID.randomUUID(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/OtherReviewContributorEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/OtherReviewContributorEntity.kt
@@ -21,7 +21,7 @@ import java.util.*
 @EntityListeners(value = [AuditingEntityListener::class])
 @Table(name = "other_review_contributor")
 @Audited(withModifiedFlag = false)
-data class OtherReviewContributorEntity(
+class OtherReviewContributorEntity(
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "elsp_review_id")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/OtherReviewContributorHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/OtherReviewContributorHistoryEntity.kt
@@ -15,8 +15,8 @@ import java.util.*
 
 @Entity
 @Immutable
-@Table(name = "other_contributor_history")
-class OtherContributorHistoryEntity(
+@Table(name = "other_review_contributor_history")
+class OtherReviewContributorHistoryEntity(
 
   @Column(length = 200, nullable = false)
   val name: String,
@@ -33,12 +33,12 @@ class OtherContributorHistoryEntity(
       insertable = false,
       updatable = false,
     ),
-    JoinColumn(name = "elsp_plan_id", referencedColumnName = "id", nullable = false, insertable = false, updatable = false),
+    JoinColumn(name = "elsp_review_id", referencedColumnName = "id", nullable = false, insertable = false, updatable = false),
   )
-  val plan: ElspPlanHistoryEntity,
+  val elspReview: ElspReviewHistoryEntity,
 
   @EmbeddedId
-  val id: OtherContributorHistoryEntityKey,
+  val id: OtherReviewContributorHistoryEntityKey,
 
   @Column(updatable = false)
   val reference: UUID = UUID.randomUUID(),
@@ -63,8 +63,8 @@ class OtherContributorHistoryEntity(
 )
 
 @Embeddable
-data class OtherContributorHistoryEntityKey(
+data class OtherReviewContributorHistoryEntityKey(
   @Column(name = "rev_id") val revisionNumber: Long,
-  @Column(name = "elsp_plan_id") val planId: UUID,
+  @Column(name = "elsp_review_id") val elspReviewId: UUID,
   @Column(name = "id") val id: UUID,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/repository/ElspPlanHistoryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/repository/ElspPlanHistoryRepository.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository
 
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ElspPlanHistoryEntity
@@ -7,5 +8,6 @@ import java.util.UUID
 
 @Repository
 interface ElspPlanHistoryRepository : JpaRepository<ElspPlanHistoryEntity, UUID> {
+  @EntityGraph(attributePaths = ["otherContributors"])
   fun findAllByPrisonNumber(prisonNumber: String): List<ElspPlanHistoryEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/repository/ElspPlanRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/repository/ElspPlanRepository.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository
 
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ElspPlanEntity
@@ -7,6 +8,7 @@ import java.util.UUID
 
 @Repository
 interface ElspPlanRepository : JpaRepository<ElspPlanEntity, UUID> {
+  @EntityGraph(attributePaths = ["otherContributors"])
   fun findByPrisonNumber(prisonNumber: String): ElspPlanEntity?
   fun existsByPrisonNumber(prisonNumber: String): Boolean
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/repository/ElspReviewHistoryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/repository/ElspReviewHistoryRepository.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository
 
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ElspReviewHistoryEntity
@@ -7,5 +8,6 @@ import java.util.UUID
 
 @Repository
 interface ElspReviewHistoryRepository : JpaRepository<ElspReviewHistoryEntity, UUID> {
+  @EntityGraph(attributePaths = ["otherContributors"])
   fun findAllByPrisonNumber(prisonNumber: String): List<ElspReviewHistoryEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/repository/ElspReviewHistoryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/repository/ElspReviewHistoryRepository.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ElspReviewHistoryEntity
+import java.util.UUID
+
+@Repository
+interface ElspReviewHistoryRepository : JpaRepository<ElspReviewHistoryEntity, UUID> {
+  fun findAllByPrisonNumber(prisonNumber: String): List<ElspReviewHistoryEntity>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/repository/ElspReviewRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/repository/ElspReviewRepository.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository
 
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ElspReviewEntity
@@ -7,5 +8,6 @@ import java.util.UUID
 
 @Repository
 interface ElspReviewRepository : JpaRepository<ElspReviewEntity, UUID> {
+  @EntityGraph(attributePaths = ["otherContributors"])
   fun findAllByPrisonNumber(prisonNumber: String): List<ElspReviewEntity>
 }


### PR DESCRIPTION
Sorry for the messy commit history on this PR. Basically I've implemented the review history retrieval (just for the tests to check the history was inserted the actual review history retrieval API is in a future ticket)

Original Thought:
I hit a few snags WRT the retrieval of the otherContributors on the plan (and review) essentially they were causing stack overflow issues. Making the classes non data classes fixed this - basically the generated toString methods were the general cause of this: https://www.baeldung.com/kotlin/jpa#data-classes - I may go through and update all the entities to be non data classes in a future PR. 
But after talking to the team decided to keep data classes and override the .equals and .toString methods

I had previously make some of the fetch types EAGER so have also removed those. 