### PR TITLE
adding screening date to the individual challenges and strengths

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/mapper/ALNScreenerMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/mapper/ALNScreenerMapper.kt
@@ -20,8 +20,8 @@ class ALNScreenerMapper(
     ALNScreenerResponse(
       reference = reference,
       screenerDate = screeningDate,
-      challenges = challenges.map(challengeMapper::toModel),
-      strengths = strengths.map(strengthMapper::toModel),
+      challenges = entity.challenges.map { challengeMapper.toModel(it, screenerDate = screeningDate) },
+      strengths = entity.strengths.map { strengthMapper.toModel(it, screenerDate = screeningDate) },
       createdBy = createdBy!!,
       createdByDisplayName = createdByName,
       createdAt = instantMapper.toOffsetDateTime(createdAt)!!,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/CreateALNScreenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/CreateALNScreenerTest.kt
@@ -159,7 +159,10 @@ class CreateALNScreenerTest : IntegrationTestBase() {
     assertThat(screener.challenges.map { it.challengeType.code }).containsExactlyInAnyOrder("MEMORY", "SPEED_OF_CALCULATION")
     assertThat(screener.strengths.map { it.strengthType.code }).containsExactlyInAnyOrder("PEOPLE_PERSON", "SPATIAL_AWARENESS")
     assertThat(screener.createdBy).isEqualTo("testuser")
-    assertThat(screener.createdByDisplayName).isEqualTo("Test User") // This depends on what `stubGetDisplayName` returns
+    assertThat(screener.createdByDisplayName).isEqualTo("Test User")
+    assertThat(screener.challenges.map { it.alnScreenerDate }).containsOnly(screenerDate)
+    assertThat(screener.strengths.map { it.alnScreenerDate }).containsOnly(screenerDate)
+
   }
 
   private fun createChallengesList(): List<ALNChallenge> = listOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/CreateALNScreenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/CreateALNScreenerTest.kt
@@ -162,7 +162,6 @@ class CreateALNScreenerTest : IntegrationTestBase() {
     assertThat(screener.createdByDisplayName).isEqualTo("Test User")
     assertThat(screener.challenges.map { it.alnScreenerDate }).containsOnly(screenerDate)
     assertThat(screener.strengths.map { it.alnScreenerDate }).containsOnly(screenerDate)
-
   }
 
   private fun createChallengesList(): List<ALNChallenge> = listOf(


### PR DESCRIPTION
Although the screening date was included as part of the ALNScreener wrapper - also added the screening date to the challenges/strengths for consistency 