### PR TITLE
make deadline dates configurable

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/config/Constants.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/config/Constants.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.config
+
+class Constants {
+  companion object {
+    const val PLAN_DEADLINE_DAYS_TO_ADD: Long = 5
+    const val REVIEW_DEADLINE_DAYS_TO_ADD: Long = 5 // change this if we need to change the minimum review date
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/PlanCreationScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/PlanCreationScheduleService.kt
@@ -4,6 +4,7 @@ import jakarta.transaction.Transactional
 import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.config.Constants.Companion.PLAN_DEADLINE_DAYS_TO_ADD
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleEntity
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleStatus
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.ElspPlanRepository
@@ -138,8 +139,8 @@ class PlanCreationScheduleService(
   }
 
   fun getDeadlineDate(educationStartDate: LocalDate): LocalDate {
-    val startDatePlusFive = workingDayService.getNextWorkingDayNDaysFromDate(5, educationStartDate)
-    val pesPlusFive = workingDayService.getNextWorkingDayNDaysFromDate(5, pesContractDate)
+    val startDatePlusFive = workingDayService.getNextWorkingDayNDaysFromDate(PLAN_DEADLINE_DAYS_TO_ADD, educationStartDate)
+    val pesPlusFive = workingDayService.getNextWorkingDayNDaysFromDate(PLAN_DEADLINE_DAYS_TO_ADD, pesContractDate)
     return maxOf(startDatePlusFive, pesPlusFive)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/ReviewScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/ReviewScheduleService.kt
@@ -4,6 +4,7 @@ import jakarta.transaction.Transactional
 import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.config.Constants.Companion.REVIEW_DEADLINE_DAYS_TO_ADD
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ReviewScheduleEntity
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ReviewScheduleStatus
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.ElspReviewRepository
@@ -105,8 +106,8 @@ class ReviewScheduleService(
   }
 
   fun getDeadlineDate(educationStartDate: LocalDate): LocalDate {
-    val startDatePlusFive = workingDayService.getNextWorkingDayNDaysFromDate(5, educationStartDate)
-    val pesPlusFive = workingDayService.getNextWorkingDayNDaysFromDate(5, pesContractDate)
+    val startDatePlusFive = workingDayService.getNextWorkingDayNDaysFromDate(REVIEW_DEADLINE_DAYS_TO_ADD, educationStartDate)
+    val pesPlusFive = workingDayService.getNextWorkingDayNDaysFromDate(REVIEW_DEADLINE_DAYS_TO_ADD, pesContractDate)
     return maxOf(startDatePlusFive, pesPlusFive)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/PlanCreationScheduleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/PlanCreationScheduleServiceTest.kt
@@ -14,6 +14,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.config.Constants.Companion.PLAN_DEADLINE_DAYS_TO_ADD
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.NeedSource.ALN_SCREENER
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleEntity
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleStatus
@@ -95,12 +96,16 @@ class PlanCreationScheduleServiceTest {
     )
 
     // set up common working day scenarios:
-    lenient().whenever(workingDayService.getNextWorkingDayNDaysFromDate(5, LocalDate.now())).thenReturn(LocalDate.now().plusDays(5))
-    lenient().whenever(workingDayService.getNextWorkingDayNDaysFromDate(5, LocalDate.of(2025, 10, 1)))
-      .thenReturn(LocalDate.of(2025, 10, 1).plusDays(5))
-    lenient().whenever(workingDayService.getNextWorkingDayNDaysFromDate(5, LocalDate.now().plusMonths(6))).thenReturn(LocalDate.now().plusMonths(6).plusDays(5))
-    lenient().whenever(workingDayService.getNextWorkingDayNDaysFromDate(5, LocalDate.of(2024, 10, 1)))
-      .thenReturn(LocalDate.of(2024, 10, 1).plusDays(5))
+    lenient().whenever(workingDayService.getNextWorkingDayNDaysFromDate(PLAN_DEADLINE_DAYS_TO_ADD, LocalDate.now())).thenReturn(
+      LocalDate.now().plusDays(
+        PLAN_DEADLINE_DAYS_TO_ADD,
+      ),
+    )
+    lenient().whenever(workingDayService.getNextWorkingDayNDaysFromDate(PLAN_DEADLINE_DAYS_TO_ADD, LocalDate.of(2025, 10, 1)))
+      .thenReturn(LocalDate.of(2025, 10, 1).plusDays(PLAN_DEADLINE_DAYS_TO_ADD))
+    lenient().whenever(workingDayService.getNextWorkingDayNDaysFromDate(PLAN_DEADLINE_DAYS_TO_ADD, LocalDate.now().plusMonths(6))).thenReturn(LocalDate.now().plusMonths(6).plusDays(PLAN_DEADLINE_DAYS_TO_ADD))
+    lenient().whenever(workingDayService.getNextWorkingDayNDaysFromDate(PLAN_DEADLINE_DAYS_TO_ADD, LocalDate.of(2024, 10, 1)))
+      .thenReturn(LocalDate.of(2024, 10, 1).plusDays(PLAN_DEADLINE_DAYS_TO_ADD))
   }
 
   private fun setUpService() = PlanCreationScheduleService(
@@ -147,12 +152,12 @@ class PlanCreationScheduleServiceTest {
   }
 
   @Test
-  fun `getDeadlineDate returns max of start date plus 5WD and PES plus 5WD`() {
+  fun `getDeadlineDate returns max of start date plus DEADLINE_DAYS_TO_ADD and PES plus DEADLINE_DAYS_TO_ADD`() {
     val start = LocalDate.parse("2024-09-01")
-    whenever(workingDayService.getNextWorkingDayNDaysFromDate(5, start)).thenReturn(LocalDate.parse("2024-09-06"))
+    whenever(workingDayService.getNextWorkingDayNDaysFromDate(PLAN_DEADLINE_DAYS_TO_ADD, start)).thenReturn(LocalDate.parse("2024-09-06"))
 
     val result = service.getDeadlineDate(start)
-    assertEquals(LocalDate.parse("2025-10-06"), result)
+    assertEquals(LocalDate.parse("2025-10-01").plusDays(PLAN_DEADLINE_DAYS_TO_ADD), result)
   }
 
   @Test


### PR DESCRIPTION
Because the review deadline date logic is potentially changing this PR is to set up constants for the two different deadline dates and make sure the tests use the same constants - this is so that the the review deadline date can be set to, say, 23 days in the future. 

I have run the tests with the date set to 23 days and they all worked successfully. 