### PR TITLE
Increased the number of deadline days for reviews

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/config/Constants.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/config/Constants.kt
@@ -3,6 +3,6 @@ package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.config
 class Constants {
   companion object {
     const val PLAN_DEADLINE_DAYS_TO_ADD: Long = 5
-    const val REVIEW_DEADLINE_DAYS_TO_ADD: Long = 5 // change this if we need to change the minimum review date
+    const val REVIEW_DEADLINE_DAYS_TO_ADD: Long = 23 // change this back to 5 days when the review journey is complete
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/ReviewScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/ReviewScheduleService.kt
@@ -102,6 +102,7 @@ class ReviewScheduleService(
       existing.deadlineDate = desired
       reviewScheduleRepository.save(existing)
       eventPublisher.createAndPublishReviewScheduleEvent(prisonNumber)
+      log.info("Review schedule deadline date updated to $desired for $prisonNumber, days to add was configured as $REVIEW_DEADLINE_DAYS_TO_ADD days")
     }
   }
 


### PR DESCRIPTION
As the review journey is going to be delayed this is to prevent any review from being automatically updated to have a deadline before November <-- in dev this will be today + 23 working days but in reality we don't go live until October therefore it will be 1 October plus 23 working days which will be 3rd November. 