### PR TITLE
Allow user to complete a previously refused plan

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/PlanCreationScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/PlanCreationScheduleService.kt
@@ -124,7 +124,7 @@ class PlanCreationScheduleService(
     clearDeadlineDate: Boolean = false,
   ) {
     planCreationScheduleRepository.findByPrisonNumber(prisonNumber)
-      ?.takeIf { it.status == PlanCreationScheduleStatus.SCHEDULED }
+      ?.takeIf { it.status == PlanCreationScheduleStatus.SCHEDULED || it.status == PlanCreationScheduleStatus.EXEMPT_PRISONER_NOT_COMPLY }
       ?.let {
         it.status = status
         it.exemptionReason = exemptionReason
@@ -144,9 +144,11 @@ class PlanCreationScheduleService(
     return maxOf(startDatePlusFive, pesPlusFive)
   }
 
+  // Can only complete a schedule if it is SCHEDULED or EXEMPT_PRISONER_NOT_COMPLY the latter is because a person may
+  // decide to create a plan despite previously not wanting to.
   fun completeSchedule(prisonNumber: String, prisonId: String) {
     planCreationScheduleRepository.findByPrisonNumber(prisonNumber)
-      ?.takeIf { it.status == PlanCreationScheduleStatus.SCHEDULED }
+      ?.takeIf { it.status == PlanCreationScheduleStatus.SCHEDULED || it.status == PlanCreationScheduleStatus.EXEMPT_PRISONER_NOT_COMPLY }
       ?.let {
         it.status = PlanCreationScheduleStatus.COMPLETED
         it.updatedAtPrison = prisonId

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/messaging/CuriousEducationTriggerEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/messaging/CuriousEducationTriggerEventTest.kt
@@ -99,6 +99,21 @@ class CuriousEducationTriggerEventTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `should process Curious Education domain event and mark the person as out of education when the person had refused a plan`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+    stubGetTokenFromHmppsAuth()
+    // person has a need:
+    aValidChallengeExists(prisonNumber)
+    aValidPlanCreationScheduleExists(prisonNumber, status = PlanCreationScheduleStatus.EXEMPT_PRISONER_NOT_COMPLY)
+    putInEducationAndValidate(prisonNumber)
+    // Then
+    endEducationAndValidate(prisonNumber)
+    val planCreationSchedule = planCreationScheduleRepository.findByPrisonNumber(prisonNumber)
+    Assertions.assertThat(planCreationSchedule!!.status).isEqualTo(PlanCreationScheduleStatus.EXEMPT_NOT_IN_EDUCATION)
+  }
+
+  @Test
   fun `should process Curious Education domain event and mark the person as out of education and Exempt the planCreationSchedule`() {
     // Given
     val prisonNumber = randomValidPrisonNumber()


### PR DESCRIPTION
And complete the plan schedule - previously this was not completing the schedule when the person had refused a plan in the past. 