### PR TITLE
give SAN schedules a future date instead of null

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/config/Constants.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/config/Constants.kt
@@ -1,8 +1,11 @@
 package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.config
 
+import java.time.LocalDate
+
 class Constants {
   companion object {
     const val PLAN_DEADLINE_DAYS_TO_ADD: Long = 5
     const val REVIEW_DEADLINE_DAYS_TO_ADD: Long = 23 // change this back to 5 days when the review journey is complete
+    val IN_THE_FUTURE_DATE: LocalDate = LocalDate.of(2099, 12, 31)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/PlanCreationScheduleEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/PlanCreationScheduleEntity.kt
@@ -34,7 +34,7 @@ data class PlanCreationScheduleEntity(
   val prisonNumber: String,
 
   @Column
-  var deadlineDate: LocalDate?,
+  var deadlineDate: LocalDate,
 
   @Column(name = "earliest_start_date")
   var earliestStartDate: LocalDate?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/PlanCreationScheduleHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/PlanCreationScheduleHistoryEntity.kt
@@ -31,7 +31,7 @@ data class PlanCreationScheduleHistoryEntity(
   val prisonNumber: String,
 
   @Column(name = "deadline_date")
-  val deadlineDate: LocalDate?,
+  val deadlineDate: LocalDate,
 
   @Column(name = "earliest_start_date")
   val earliestStartDate: LocalDate?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ReviewScheduleEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ReviewScheduleEntity.kt
@@ -28,7 +28,7 @@ data class ReviewScheduleEntity(
   val prisonNumber: String,
 
   @Column
-  var deadlineDate: LocalDate? = null,
+  var deadlineDate: LocalDate,
 
   @Column
   @Enumerated(value = EnumType.STRING)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ReviewScheduleHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ReviewScheduleHistoryEntity.kt
@@ -27,7 +27,7 @@ data class ReviewScheduleHistoryEntity(
   val prisonNumber: String,
 
   @Column(name = "deadline_date")
-  val deadlineDate: LocalDate? = null,
+  val deadlineDate: LocalDate,
 
   @Column
   @Enumerated(value = EnumType.STRING)

--- a/src/main/resources/db/migration/common/V2025.09.8.0001__make_deadline_date_non_nullable.sql
+++ b/src/main/resources/db/migration/common/V2025.09.8.0001__make_deadline_date_non_nullable.sql
@@ -1,0 +1,27 @@
+UPDATE plan_creation_schedule
+SET deadline_date = '2099-12-31'
+WHERE deadline_date IS NULL;
+
+ALTER TABLE plan_creation_schedule
+    ALTER COLUMN deadline_date SET NOT NULL;
+
+UPDATE plan_creation_schedule_history
+SET deadline_date = '2099-12-31'
+WHERE deadline_date IS NULL;
+
+ALTER TABLE plan_creation_schedule_history
+    ALTER COLUMN deadline_date SET NOT NULL;
+
+UPDATE review_schedule
+SET deadline_date = '2099-12-31'
+WHERE deadline_date IS NULL;
+
+ALTER TABLE review_schedule
+    ALTER COLUMN deadline_date SET NOT NULL;
+
+UPDATE review_schedule_history
+SET deadline_date = '2099-12-31'
+WHERE deadline_date IS NULL;
+
+ALTER TABLE review_schedule_history
+    ALTER COLUMN deadline_date SET NOT NULL;

--- a/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
+++ b/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.1.1
 info:
   title: Support For Additional Needs API
-  version: '0.12.1'
+  version: '0.12.2'
   description: Support For Additional Needs API
   contact:
     name: Learning and Work Progress team
@@ -1428,6 +1428,7 @@ components:
       required:
         - reference
         - status
+        - deadlineDate
 
     ConditionResponse:
       title: ConditionResponse
@@ -1898,6 +1899,7 @@ components:
       required:
         - reference
         - status
+        - deadlineDate
 
     PlanActionStatus:
       title: PlanActionStatus

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/IntegrationTestBase.kt
@@ -249,7 +249,7 @@ abstract class IntegrationTestBase {
   fun aValidPlanCreationScheduleExists(
     prisonNumber: String,
     status: PlanCreationScheduleStatus = PlanCreationScheduleStatus.SCHEDULED,
-    deadlineDate: LocalDate? = LocalDate.now().minusMonths(1),
+    deadlineDate: LocalDate = LocalDate.now().minusMonths(1),
   ) {
     val planCreationScheduleEntity =
       PlanCreationScheduleEntity(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/messaging/CuriousALNTriggerEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/messaging/CuriousALNTriggerEventTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.parallel.Isolated
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.common.aValidEducationALNAssessmentUpdateAdditionalInformation
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.common.aValidHmppsDomainEventsSqsMessage
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.config.Constants.Companion.IN_THE_FUTURE_DATE
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleStatus
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ReviewScheduleStatus
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.TimelineEventType
@@ -63,7 +64,7 @@ class CuriousALNTriggerEventTest : IntegrationTestBase() {
     val planCreationSchedule = planCreationScheduleRepository.findByPrisonNumber(prisonNumber)
 
     Assertions.assertThat(planCreationSchedule).isNotNull
-    Assertions.assertThat(planCreationSchedule!!.deadlineDate).isNull()
+    Assertions.assertThat(planCreationSchedule!!.deadlineDate).isEqualTo(IN_THE_FUTURE_DATE)
     Assertions.assertThat(planCreationSchedule.earliestStartDate).isNull()
     Assertions.assertThat(planCreationSchedule.status).isEqualTo(PlanCreationScheduleStatus.SCHEDULED)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/messaging/CuriousALNTriggerEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/messaging/CuriousALNTriggerEventTest.kt
@@ -85,7 +85,7 @@ class CuriousALNTriggerEventTest : IntegrationTestBase() {
     val reviewScheduleEntity = reviewScheduleRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber)
 
     Assertions.assertThat(reviewScheduleEntity).isNotNull
-    Assertions.assertThat(reviewScheduleEntity!!.deadlineDate).isNull()
+    Assertions.assertThat(reviewScheduleEntity!!.deadlineDate).isEqualTo(IN_THE_FUTURE_DATE)
     Assertions.assertThat(reviewScheduleEntity.status).isEqualTo(ReviewScheduleStatus.SCHEDULED)
   }
 
@@ -124,7 +124,7 @@ class CuriousALNTriggerEventTest : IntegrationTestBase() {
     createALNAssessmentMessage(prisonNumber, curiousReference, hasNeed = true)
 
     val reviewScheduleEntity = reviewScheduleRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber)
-    Assertions.assertThat(reviewScheduleEntity!!.deadlineDate).isNull()
+    Assertions.assertThat(reviewScheduleEntity!!.deadlineDate).isEqualTo(IN_THE_FUTURE_DATE)
     Assertions.assertThat(reviewScheduleEntity.status).isEqualTo(ReviewScheduleStatus.SCHEDULED)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/messaging/CuriousEducationTriggerEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/messaging/CuriousEducationTriggerEventTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.parallel.Isolated
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.common.aValidEducationStatusUpdateAdditionalInformation
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.common.aValidHmppsDomainEventsSqsMessage
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.config.Constants.Companion.IN_THE_FUTURE_DATE
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.config.Constants.Companion.PLAN_DEADLINE_DAYS_TO_ADD
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.config.Constants.Companion.REVIEW_DEADLINE_DAYS_TO_ADD
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleStatus
@@ -81,7 +82,7 @@ class CuriousEducationTriggerEventTest : IntegrationTestBase() {
     val planCreationSchedule = planCreationScheduleRepository.findByPrisonNumber(prisonNumber)
     Assertions.assertThat(planCreationSchedule!!.status).isEqualTo(PlanCreationScheduleStatus.SCHEDULED)
     Assertions.assertThat(planCreationSchedule.earliestStartDate).isNull()
-    Assertions.assertThat(planCreationSchedule.deadlineDate).isNull()
+    Assertions.assertThat(planCreationSchedule.deadlineDate).isEqualTo(IN_THE_FUTURE_DATE)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/CreateChallengeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/CreateChallengeTest.kt
@@ -145,7 +145,7 @@ class CreateChallengeTest : IntegrationTestBase() {
     val actual = response.responseBody.blockFirst()
     assertThat(actual).isNotNull()
     val reviewScheduleEntity = reviewScheduleRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber)
-    assertThat(reviewScheduleEntity?.deadlineDate).isNull()
+    assertThat(reviewScheduleEntity?.deadlineDate).isEqualTo(IN_THE_FUTURE_DATE)
     assertThat(reviewScheduleEntity?.status).isEqualTo(ReviewScheduleStatus.SCHEDULED)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/CreateChallengeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/CreateChallengeTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.resou
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.config.Constants.Companion.IN_THE_FUTURE_DATE
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.IdentificationSource
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleStatus
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ReviewScheduleStatus
@@ -87,7 +88,7 @@ class CreateChallengeTest : IntegrationTestBase() {
     val actual = response.responseBody.blockFirst()
     assertThat(actual).isNotNull()
     val planCreationScheduleEntity = planCreationScheduleRepository.findByPrisonNumber(prisonNumber)
-    assertThat(planCreationScheduleEntity?.deadlineDate).isNull()
+    assertThat(planCreationScheduleEntity?.deadlineDate).isEqualTo(IN_THE_FUTURE_DATE)
     assertThat(planCreationScheduleEntity?.status).isEqualTo(PlanCreationScheduleStatus.SCHEDULED)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/CreateConditionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/CreateConditionTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.resou
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.config.Constants.Companion.IN_THE_FUTURE_DATE
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleStatus
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ReviewScheduleStatus
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.IntegrationTestBase
@@ -93,7 +94,7 @@ class CreateConditionTest : IntegrationTestBase() {
     assertThat(actual).isNotNull()
 
     val planCreationScheduleEntity = planCreationScheduleRepository.findByPrisonNumber(prisonNumber)
-    assertThat(planCreationScheduleEntity?.deadlineDate).isNull()
+    assertThat(planCreationScheduleEntity?.deadlineDate).isEqualTo(IN_THE_FUTURE_DATE)
     assertThat(planCreationScheduleEntity?.status).isEqualTo(PlanCreationScheduleStatus.SCHEDULED)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/CreateConditionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/CreateConditionTest.kt
@@ -153,7 +153,7 @@ class CreateConditionTest : IntegrationTestBase() {
     assertThat(actual).isNotNull()
 
     val reviewScheduleEntity = reviewScheduleRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber)
-    assertThat(reviewScheduleEntity?.deadlineDate).isNull()
+    assertThat(reviewScheduleEntity?.deadlineDate).isEqualTo(IN_THE_FUTURE_DATE)
     assertThat(reviewScheduleEntity?.status).isEqualTo(ReviewScheduleStatus.SCHEDULED)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/UpdatePlanCreationScheduleStatusTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/UpdatePlanCreationScheduleStatusTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.resou
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.config.Constants.Companion.IN_THE_FUTURE_DATE
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleStatus.COMPLETED
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.randomValidPrisonNumber
@@ -47,7 +48,7 @@ class UpdatePlanCreationScheduleStatusTest : IntegrationTestBase() {
 
     assertThat(actual).isNotNull()
     assertThat(actual!!.planCreationSchedules[0].status).isEqualTo(PlanCreationStatus.EXEMPT_PRISONER_NOT_COMPLY)
-    assertThat(actual.planCreationSchedules[0].deadlineDate).isNull()
+    assertThat(actual.planCreationSchedules[0].deadlineDate).isEqualTo(IN_THE_FUTURE_DATE)
     assertThat(actual.planCreationSchedules[0].exemptionReason).isEqualTo(PlanCreationScheduleExemptionReason.EXEMPT_NOT_REQUIRED)
     assertThat(actual.planCreationSchedules[0].exemptionDetail).isEqualTo("because I say so")
     assertThat(actual.planCreationSchedules[0].updatedAtPrison).isEqualTo("LWI")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/EducationSupportPlanReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/EducationSupportPlanReviewServiceTest.kt
@@ -71,7 +71,7 @@ class EducationSupportPlanReviewServiceTest {
     // Given
     val prisonNumber = randomValidPrisonNumber()
     val request = aValidSupportPlanReviewRequest()
-    val reviewSchedule = ReviewScheduleEntity(reference = UUID.randomUUID(), prisonNumber = prisonNumber, status = ReviewScheduleStatus.COMPLETED, createdAtPrison = "BXI", updatedAtPrison = "BXI")
+    val reviewSchedule = ReviewScheduleEntity(reference = UUID.randomUUID(), prisonNumber = prisonNumber, status = ReviewScheduleStatus.COMPLETED, createdAtPrison = "BXI", updatedAtPrison = "BXI", deadlineDate = LocalDate.now())
 
     given(educationSupportPlanService.hasPlan(prisonNumber)).willReturn(true)
     given(reviewScheduleRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber)).willReturn(reviewSchedule)
@@ -86,7 +86,7 @@ class EducationSupportPlanReviewServiceTest {
     // Given
     val prisonNumber = randomValidPrisonNumber()
     val request = aValidSupportPlanReviewRequest(nextReviewDate = LocalDate.now().plusMonths(6))
-    val reviewSchedule = ReviewScheduleEntity(reference = UUID.randomUUID(), prisonNumber = prisonNumber, status = ReviewScheduleStatus.SCHEDULED, createdAtPrison = "BXI", updatedAtPrison = "BXI")
+    val reviewSchedule = ReviewScheduleEntity(reference = UUID.randomUUID(), prisonNumber = prisonNumber, status = ReviewScheduleStatus.SCHEDULED, createdAtPrison = "BXI", updatedAtPrison = "BXI", deadlineDate = LocalDate.now())
 
     given(educationSupportPlanService.hasPlan(prisonNumber)).willReturn(true)
     given(reviewScheduleRepository.findFirstByPrisonNumberOrderByUpdatedAtDesc(prisonNumber)).willReturn(reviewSchedule)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/PlanCreationScheduleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/PlanCreationScheduleServiceTest.kt
@@ -14,6 +14,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.config.Constants.Companion.IN_THE_FUTURE_DATE
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.config.Constants.Companion.PLAN_DEADLINE_DAYS_TO_ADD
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.NeedSource.ALN_SCREENER
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleEntity
@@ -146,7 +147,7 @@ class PlanCreationScheduleServiceTest {
 
   @Test
   fun `createSchedule does nothing if not in education or no need`() {
-    service.createSchedule(prisonNumber, deadlineDate = null, earliestStartDate = null)
+    service.createSchedule(prisonNumber, deadlineDate = IN_THE_FUTURE_DATE, earliestStartDate = null)
 
     verify(planCreationScheduleRepository, never()).saveAndFlush(any())
   }


### PR DESCRIPTION
It is very possible that someone will be in education and later have a need identified which means they have to create (or review) a plan. 

Crucially the order matters with regard to the KPI measurements. if the person has a need and then goes in to education then they have 5 days to complete the plan, it it is the other way round then they CAN create a plan but there is no deadline by which they need to complete it by. 

Originally the schedules where there was no deadline date had a null date, this was semantically - how can you have a schedule to do something with no actual date? And also Meganexus were confused about what null meant. Therefore we've decided to set the date (where it would have been null) to an arbitrary date in the future of 31/12/2099.   

 