### PR TITLE
updated Needs plan status

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/SearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/SearchService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.service
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.config.Constants
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PrisonerOverviewEntity
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.PrisonerOverviewRepository
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.mapper.SentenceTypeMapper
@@ -84,7 +85,7 @@ class SearchService(
 
       // Needs plan (has needs and education, no deadline, and no plan yet)
       !overview.hasPlan &&
-        overview.deadlineDate == null
+        overview.planCreationDeadlineDate == Constants.IN_THE_FUTURE_DATE
       -> PlanStatus.NEEDS_PLAN
 
       // Review due soon (within 5 working days)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/PlanActionStatusTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/PlanActionStatusTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.client.prisonersearch.Prisoner
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.client.prisonersearch.aValidPrisoner
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.config.Constants.Companion.IN_THE_FUTURE_DATE
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleStatus
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.randomValidPrisonNumber
@@ -86,6 +87,10 @@ class PlanActionStatusTest : IntegrationTestBase() {
     // needsPlan -> PRISONER_1
     prisonerInEducation(PRISONER_1.prisonerNumber)
     prisonerHasNeed(PRISONER_1.prisonerNumber)
+    aValidPlanCreationScheduleExists(
+      prisonNumber = PRISONER_1.prisonerNumber,
+      deadlineDate = IN_THE_FUTURE_DATE,
+    )
 
     // planDue -> PRISONER_2
     prisonerInEducation(PRISONER_2.prisonerNumber)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/SearchSanResultsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/resource/SearchSanResultsTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.resou
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.client.prisonersearch.aValidPrisoner
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.config.Constants.Companion.IN_THE_FUTURE_DATE
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleStatus
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.randomValidPrisonNumber
@@ -41,6 +42,7 @@ class SearchSanResultsTest : IntegrationTestBase() {
     // PRISONER_1
     prisonerInEducation(PRISONER_1.prisonerNumber)
     prisonerHasNeed(PRISONER_1.prisonerNumber)
+    aValidPlanCreationScheduleExists(prisonNumber = PRISONER_1.prisonerNumber, deadlineDate = IN_THE_FUTURE_DATE)
 
     // PlanDue
     // PRISONER_2


### PR DESCRIPTION
When I changed the deadline date to 'a date in the future' I didn't change the action status to suite. 

_Surely making the deadline date mandatory would have found that_ - I hear you say... Well since this uses the prisoner overview view to work out the status and that CAN be null since not everyone has a plan schedule. So there. 