### PR TITLE
RR-1859 Use postgres17 for test containers

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/container/PostgresContainer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/container/PostgresContainer.kt
@@ -17,7 +17,7 @@ object PostgresContainer {
 
     val logConsumer = Slf4jLogConsumer(log).withPrefix("postgresql")
 
-    return PostgreSQLContainer<Nothing>("postgres:16").apply {
+    return PostgreSQLContainer<Nothing>("postgres:17").apply {
       withEnv("HOSTNAME_EXTERNAL", "localhost")
       withExposedPorts(5432)
       withDatabaseName("support_additional_needs_api_db")


### PR DESCRIPTION
* Postgres is being updated to v17, this changes aligns the test container version used