### PR TITLE
only process actual release messages rather than all releases

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/messaging/AdditionalInformation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/messaging/AdditionalInformation.kt
@@ -56,6 +56,7 @@ sealed interface AdditionalInformation {
   ) : AdditionalInformation {
 
     val releaseTriggeredByPrisonerDeath: Boolean = nomisMovementReasonCode == "DEC"
+    val actualRelease: Boolean = reason == Reason.RELEASED
 
     enum class Reason {
       TEMPORARY_ABSENCE_RELEASE,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/ScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/ScheduleService.kt
@@ -44,12 +44,15 @@ class ScheduleService(
    */
   @Transactional
   fun processReleased(info: PrisonerReleasedAdditionalInformation) {
+    log.info("prisoner ${info.nomsNumber} processing release message with reason ${info.reason}")
     if (info.releaseTriggeredByPrisonerDeath) {
       planCreationScheduleService.exemptSchedule(info.nomsNumber, PlanCreationScheduleStatus.EXEMPT_PRISONER_DEATH, prisonId = info.prisonId)
       reviewScheduleService.exemptSchedule(info.nomsNumber, ReviewScheduleStatus.EXEMPT_PRISONER_DEATH, prisonId = info.prisonId)
-    } else {
+    } else if (info.actualRelease) {
       planCreationScheduleService.exemptSchedule(info.nomsNumber, PlanCreationScheduleStatus.EXEMPT_PRISONER_RELEASE, prisonId = info.prisonId)
       reviewScheduleService.exemptSchedule(info.nomsNumber, ReviewScheduleStatus.EXEMPT_PRISONER_RELEASE, prisonId = info.prisonId)
+    } else {
+      log.info("prisoner ${info.nomsNumber} release message ignored due to reason ${info.reason}")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/messaging/PrisonerReleasedEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/messaging/PrisonerReleasedEventTest.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.common.aValidPriso
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleStatus
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ReviewScheduleStatus
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation.Reason.RELEASED
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.EventType
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.randomValidPrisonNumber
 import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
@@ -62,6 +63,7 @@ class PrisonerReleasedEventTest : IntegrationTestBase() {
       eventType = EventType.PRISONER_RELEASED_FROM_PRISON,
       additionalInformation = aValidPrisonerReleasedAdditionalInformation(
         prisonNumber = prisonNumber,
+        reason = RELEASED,
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/messaging/PrisonerReleasedEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/integration/messaging/PrisonerReleasedEventTest.kt
@@ -11,7 +11,9 @@ import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.common.aValidPriso
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleStatus
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ReviewScheduleStatus
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation.Reason.RELEASED
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.AdditionalInformation.PrisonerReleasedAdditionalInformation.Reason.TEMPORARY_ABSENCE_RELEASE
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.messaging.EventType
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.randomValidPrisonNumber
 import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
@@ -39,6 +41,25 @@ class PrisonerReleasedEventTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `should process prisoner temp release event and not change the schedule status`() {
+    // Given
+    val prisonNumber = randomValidPrisonNumber()
+    aValidPlanCreationScheduleExists(prisonNumber)
+
+    // When
+    sendPrisonerReleaseMessage(prisonNumber, reason = TEMPORARY_ABSENCE_RELEASE)
+
+    // Then
+    // wait until the queue is drained / message is processed
+    await untilCallTo {
+      domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+    } matches { it == 0 }
+
+    val schedule = planCreationScheduleRepository.findByPrisonNumber(prisonNumber)
+    Assertions.assertThat(schedule!!.status).isEqualTo(PlanCreationScheduleStatus.SCHEDULED)
+  }
+
+  @Test
   fun `should process prisoner release event setting review schedule to exempt due to prisoner release`() {
     // Given
     val prisonNumber = randomValidPrisonNumber()
@@ -57,13 +78,13 @@ class PrisonerReleasedEventTest : IntegrationTestBase() {
     Assertions.assertThat(schedule!!.status).isEqualTo(ReviewScheduleStatus.EXEMPT_PRISONER_RELEASE)
   }
 
-  private fun sendPrisonerReleaseMessage(prisonNumber: String) {
+  private fun sendPrisonerReleaseMessage(prisonNumber: String, reason: PrisonerReleasedAdditionalInformation.Reason = RELEASED) {
     val sqsMessage = aValidHmppsDomainEventsSqsMessage(
       prisonNumber = prisonNumber,
       eventType = EventType.PRISONER_RELEASED_FROM_PRISON,
       additionalInformation = aValidPrisonerReleasedAdditionalInformation(
         prisonNumber = prisonNumber,
-        reason = RELEASED,
+        reason = reason,
       ),
     )
 


### PR DESCRIPTION
Was previously exempting schedules when any RELEASE message was received but really we only need to do this for actual releases and not temp, court etc. 