### PR TITLE
increase education pagesize

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/client/curious/CuriousApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/client/curious/CuriousApiClient.kt
@@ -47,7 +47,7 @@ class CuriousApiClient(
    */
   fun getEducation(prisonNumber: String): EducationDTO = try {
     curiousApiWebClient.get()
-      .uri("/learnerQualifications/v2/{prisonNumber}", prisonNumber)
+      .uri("/learnerQualifications/v2/{prisonNumber}?size=1000", prisonNumber)
       .headers {
         it.contentType = MediaType.APPLICATION_JSON
       }


### PR DESCRIPTION
An undocumented feature of the curious education endpoint is that it's paginated (not mentioned in swagger) and only has 10 items per page. Through trial and error I've worked out that the parameter 'size' is used to increase the pagesize. Hence this PR 