### PR TITLE
RR-2472 - Let JPA manage createdAt and updatedAt timestamps on entities

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/IntegrationTestBase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/IntegrationTestBase.kt
@@ -435,8 +435,9 @@ abstract class IntegrationTestBase {
       lnspSupportHours = 2,
       detail = "detail",
       createdAtPrison = "BXI",
-      createdAt = Instant.now().minus(90, ChronoUnit.DAYS),
-    )
+    ).apply {
+      createdAt = Instant.now().minus(90, ChronoUnit.DAYS)
+    }
     val ehcp = EhcpStatusEntity(prisonNumber = prisonNumber, hasCurrentEhcp = true, createdAtPrison = "BXI", updatedAtPrison = "BXI")
     ehcpStatusRepository.save(ehcp)
     return elspPlanRepository.saveAndFlush(elsp)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/EhcpStatusEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/EhcpStatusEntity.kt
@@ -3,17 +3,19 @@ package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
+import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.hibernate.Hibernate
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
+import org.hibernate.annotations.UuidGenerator
 import org.hibernate.envers.Audited
 import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.Instant
-import java.util.*
+import java.util.UUID
 
 @Entity
 @EntityListeners(value = [AuditingEntityListener::class])
@@ -23,6 +25,9 @@ data class EhcpStatusEntity(
   @Column(updatable = false)
   val prisonNumber: String,
 
+  @Column(updatable = false)
+  val reference: UUID = UUID.randomUUID(),
+
   @Column(nullable = false)
   var hasCurrentEhcp: Boolean = false,
 
@@ -31,30 +36,28 @@ data class EhcpStatusEntity(
 
   @Column
   var updatedAtPrison: String,
-
-  @Id
-  @Column
-  val id: UUID = UUID.randomUUID(),
-
-  @Column(updatable = false)
-  val reference: UUID = UUID.randomUUID(),
-
-  @CreatedBy
-  @Column(updatable = false)
-  var createdBy: String? = null,
-
-  @CreationTimestamp
-  @Column
-  var createdAt: Instant? = Instant.now(),
-
-  @LastModifiedBy
-  @Column
-  var updatedBy: String? = null,
-
-  @UpdateTimestamp
-  @Column
-  var updatedAt: Instant? = null,
 ) {
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  var id: UUID? = null
+
+  @Column(updatable = false)
+  @CreationTimestamp
+  var createdAt: Instant? = null
+
+  @Column(updatable = false)
+  @CreatedBy
+  var createdBy: String? = null
+
+  @Column
+  @UpdateTimestamp
+  var updatedAt: Instant? = null
+
+  @Column
+  @LastModifiedBy
+  var updatedBy: String? = null
+
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspPlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspPlanEntity.kt
@@ -4,18 +4,20 @@ import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
+import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import org.hibernate.Hibernate
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
+import org.hibernate.annotations.UuidGenerator
 import org.hibernate.envers.Audited
 import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.Instant
-import java.util.*
+import java.util.UUID
 
 @Entity
 @EntityListeners(value = [AuditingEntityListener::class])
@@ -24,6 +26,9 @@ import java.util.*
 data class ElspPlanEntity(
   @Column(updatable = false)
   val prisonNumber: String,
+
+  @Column(updatable = false)
+  val reference: UUID = UUID.randomUUID(),
 
   @Column(length = 200)
   val planCreatedByName: String? = null,
@@ -60,30 +65,28 @@ data class ElspPlanEntity(
 
   @OneToMany(mappedBy = "elspPlan", cascade = [CascadeType.ALL], orphanRemoval = true)
   val otherContributors: MutableList<OtherContributorEntity> = mutableListOf(),
-
-  @Id
-  @Column
-  val id: UUID = UUID.randomUUID(),
-
-  @Column(updatable = false)
-  val reference: UUID = UUID.randomUUID(),
-
-  @CreatedBy
-  @Column(updatable = false)
-  var createdBy: String? = null,
-
-  @CreationTimestamp
-  @Column
-  var createdAt: Instant? = Instant.now(),
-
-  @LastModifiedBy
-  @Column
-  var updatedBy: String? = null,
-
-  @UpdateTimestamp
-  @Column
-  var updatedAt: Instant? = null,
 ) {
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  var id: UUID? = null
+
+  @Column(updatable = false)
+  @CreationTimestamp
+  var createdAt: Instant? = null
+
+  @Column(updatable = false)
+  @CreatedBy
+  var createdBy: String? = null
+
+  @Column
+  @UpdateTimestamp
+  var updatedAt: Instant? = null
+
+  @Column
+  @LastModifiedBy
+  var updatedBy: String? = null
+
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false


### PR DESCRIPTION
Part of the problem with the SAR report test is that the ELSP Plan (and it's EHCP Status) have createdAt and updatedAt dates that are set to "now"
This is normal - we expect all our entities to be saved with createdAt and updatedAt fields. But in context of the test we want to be able to control the values of these fields so that the generated report is predictable (ie. has known values)

In context of these 2 entities, part of the problem is that the createdAt and updatedAt fields were populated in the class as `Instant.now()`, rather than letting JPA manage them (which is what we should be doing) Because they were being initialised in the class, there is no way to affect the values being set (perhaps with a fixed clock or similar)

So, the first step here is to change these entities so that the JPA managed fields (5 in total) are NOT constructor args, and are instead class members with the correct annotations, and in the case of these 2 dates fields, are not initialised in class with `Instant.now()`.
Making this change will mean that JPA is managing these values (which it should be)

A subsequent PR will start to use a `Clock` bean , and then after that we can use a fixed clock in the integration tests