### PR TITLE
Removes incorrect screener data

### DIFF
--- a/src/main/resources/db/migration/prod/V2026.04.16.0001__remove_incorrect_screener_data.sql
+++ b/src/main/resources/db/migration/prod/V2026.04.16.0001__remove_incorrect_screener_data.sql
@@ -1,0 +1,6 @@
+--- Remove screener data added in error from PRN A0490DW
+--- Jira ticket RR-2513
+
+DELETE from aln_screener
+    WHERE prison_number = 'A0490DW'
+    AND reference = '5894256e-8d68-41f9-8368-3c3c71c29afb';

--- a/src/main/resources/db/migration/prod/V2026.04.16.0002__remove_incorrect_screener_data.sql
+++ b/src/main/resources/db/migration/prod/V2026.04.16.0002__remove_incorrect_screener_data.sql
@@ -1,0 +1,10 @@
+--- Remove screener data added in error from PRN A0060AF
+--- Jira ticket RR-2514
+
+DELETE from aln_screener
+    WHERE prison_number = 'A0060AF'
+    AND reference = '4eacab58-395d-469f-ab8a-e2635ff1710a';
+
+DELETE from aln_screener
+    WHERE prison_number = 'A0060AF'
+    AND reference = 'b23461d8-31f2-46a3-a950-2185371f7547';

--- a/src/main/resources/db/migration/prod/V2026.04.16.0003__remove_incorrect_screener_data.sql
+++ b/src/main/resources/db/migration/prod/V2026.04.16.0003__remove_incorrect_screener_data.sql
@@ -1,0 +1,18 @@
+--- Remove screener data added in error from PRNs A3890EZ, A6519FK, A8454AL, A8733EY
+--- Jira ticket RR-2515
+
+DELETE from aln_screener
+    WHERE prison_number = 'A3890EZ'
+    AND reference = 'a9ae74d6-029b-4a0c-b4ad-a4602d4795cb';
+
+DELETE from aln_screener
+    WHERE prison_number = 'A6519FK'
+    AND reference = 'ececa23c-3fd8-47c5-995f-82b018df4204';
+
+DELETE from aln_screener
+    WHERE prison_number = 'A8454AL'
+    AND reference = 'd536e8c5-d8bf-4c39-a0c9-e4812e38f3cd';
+
+DELETE from aln_screener
+    WHERE prison_number = 'A8733EY'
+    AND reference = 'ac3d6511-0326-4b1b-958f-de3961eb9901';


### PR DESCRIPTION
Removes specific entries from the `aln_screener` table that were added in error. This action corrects data integrity issues for several prison numbers by deleting the incorrect records via database migration scripts.

Relates to RR-2513, RR-2514, RR-2515