### PR TITLE
RR-2472 - Use spring annotations for 'create at' and 'updated at' fields

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/config/ClockConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/config/ClockConfiguration.kt
@@ -2,11 +2,17 @@ package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.config
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.data.auditing.DateTimeProvider
 import java.time.Clock
+import java.time.Instant
+import java.util.Optional
 
 @Configuration
 class ClockConfiguration {
 
   @Bean
   fun clock(): Clock = Clock.systemDefaultZone()
+
+  @Bean
+  fun dateTimeProvider(clock: Clock): DateTimeProvider = DateTimeProvider { Optional.of(Instant.now(clock)) }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/BaseAuditableEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/BaseAuditableEntity.kt
@@ -3,10 +3,10 @@ package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity
 import jakarta.persistence.Column
 import jakarta.persistence.Id
 import jakarta.persistence.MappedSuperclass
-import org.hibernate.annotations.CreationTimestamp
-import org.hibernate.annotations.UpdateTimestamp
 import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.annotation.LastModifiedDate
 import java.time.Instant
 import java.util.UUID
 
@@ -23,7 +23,7 @@ abstract class BaseAuditableEntity {
   @Column(updatable = false)
   var createdBy: String? = null
 
-  @CreationTimestamp
+  @CreatedDate
   @Column(updatable = false)
   var createdAt: Instant? = null
 
@@ -31,7 +31,7 @@ abstract class BaseAuditableEntity {
   @Column
   var updatedBy: String? = null
 
-  @UpdateTimestamp
+  @LastModifiedDate
   @Column
   var updatedAt: Instant? = null
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/EhcpStatusEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/EhcpStatusEntity.kt
@@ -7,12 +7,12 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.hibernate.Hibernate
-import org.hibernate.annotations.CreationTimestamp
-import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.annotations.UuidGenerator
 import org.hibernate.envers.Audited
 import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.Instant
 import java.util.UUID
@@ -43,7 +43,7 @@ data class EhcpStatusEntity(
   var id: UUID? = null
 
   @Column(updatable = false)
-  @CreationTimestamp
+  @CreatedDate
   var createdAt: Instant? = null
 
   @Column(updatable = false)
@@ -51,7 +51,7 @@ data class EhcpStatusEntity(
   var createdBy: String? = null
 
   @Column
-  @UpdateTimestamp
+  @LastModifiedDate
   var updatedAt: Instant? = null
 
   @Column

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspPlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspPlanEntity.kt
@@ -9,12 +9,12 @@ import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import org.hibernate.Hibernate
-import org.hibernate.annotations.CreationTimestamp
-import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.annotations.UuidGenerator
 import org.hibernate.envers.Audited
 import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.Instant
 import java.util.UUID
@@ -72,7 +72,7 @@ data class ElspPlanEntity(
   var id: UUID? = null
 
   @Column(updatable = false)
-  @CreationTimestamp
+  @CreatedDate
   var createdAt: Instant? = null
 
   @Column(updatable = false)
@@ -80,7 +80,7 @@ data class ElspPlanEntity(
   var createdBy: String? = null
 
   @Column
-  @UpdateTimestamp
+  @LastModifiedDate
   var updatedAt: Instant? = null
 
   @Column

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspReviewEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ElspReviewEntity.kt
@@ -9,14 +9,14 @@ import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import org.hibernate.Hibernate
-import org.hibernate.annotations.CreationTimestamp
-import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.envers.Audited
 import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.Instant
-import java.util.*
+import java.util.UUID
 
 @Entity
 @EntityListeners(value = [AuditingEntityListener::class])
@@ -64,7 +64,7 @@ data class ElspReviewEntity(
   @Column(updatable = false)
   var createdBy: String? = null,
 
-  @CreationTimestamp
+  @CreatedDate
   @Column(updatable = false)
   var createdAt: Instant? = null,
 
@@ -72,7 +72,7 @@ data class ElspReviewEntity(
   @Column
   var updatedBy: String? = null,
 
-  @UpdateTimestamp
+  @LastModifiedDate
   @Column
   var updatedAt: Instant? = null,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/OtherContributorEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/OtherContributorEntity.kt
@@ -7,14 +7,14 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
-import org.hibernate.annotations.CreationTimestamp
-import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.envers.Audited
 import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.Instant
-import java.util.*
+import java.util.UUID
 
 @Entity
 @EntityListeners(value = [AuditingEntityListener::class])
@@ -49,7 +49,7 @@ data class OtherContributorEntity(
   @Column(updatable = false)
   var createdBy: String? = null,
 
-  @CreationTimestamp
+  @CreatedDate
   @Column(updatable = false)
   var createdAt: Instant? = null,
 
@@ -57,7 +57,7 @@ data class OtherContributorEntity(
   @Column
   var updatedBy: String? = null,
 
-  @UpdateTimestamp
+  @LastModifiedDate
   @Column
   var updatedAt: Instant? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/OtherReviewContributorEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/OtherReviewContributorEntity.kt
@@ -7,14 +7,14 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
-import org.hibernate.annotations.CreationTimestamp
-import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.envers.Audited
 import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.Instant
-import java.util.*
+import java.util.UUID
 
 @Entity
 @EntityListeners(value = [AuditingEntityListener::class])
@@ -49,7 +49,7 @@ class OtherReviewContributorEntity(
   @Column(updatable = false)
   var createdBy: String? = null,
 
-  @CreationTimestamp
+  @CreatedDate
   @Column(updatable = false)
   var createdAt: Instant? = null,
 
@@ -57,7 +57,7 @@ class OtherReviewContributorEntity(
   @Column
   var updatedBy: String? = null,
 
-  @UpdateTimestamp
+  @LastModifiedDate
   @Column
   var updatedAt: Instant? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/PlanCreationScheduleEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/PlanCreationScheduleEntity.kt
@@ -10,13 +10,13 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import jakarta.persistence.Version
-import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.JdbcTypeCode
-import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.envers.Audited
 import org.hibernate.type.SqlTypes
 import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.Instant
 import java.time.LocalDate
@@ -73,7 +73,7 @@ data class PlanCreationScheduleEntity(
   @Column(updatable = false)
   var createdBy: String? = null,
 
-  @CreationTimestamp
+  @CreatedDate
   @Column(updatable = false)
   var createdAt: Instant? = null,
 
@@ -81,7 +81,7 @@ data class PlanCreationScheduleEntity(
   @Column
   var updatedBy: String? = null,
 
-  @UpdateTimestamp
+  @LastModifiedDate
   @Column
   var updatedAt: Instant? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ReviewScheduleEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/ReviewScheduleEntity.kt
@@ -8,11 +8,11 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import jakarta.persistence.Version
-import org.hibernate.annotations.CreationTimestamp
-import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.envers.Audited
 import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.Instant
 import java.time.LocalDate
@@ -58,7 +58,7 @@ data class ReviewScheduleEntity(
   @Column(updatable = false)
   var createdBy: String? = null,
 
-  @CreationTimestamp
+  @CreatedDate
   @Column(updatable = false)
   var createdAt: Instant? = null,
 
@@ -66,7 +66,7 @@ data class ReviewScheduleEntity(
   @Column
   var updatedBy: String? = null,
 
-  @UpdateTimestamp
+  @LastModifiedDate
   @Column
   var updatedAt: Instant? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/TimelineEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/TimelineEntity.kt
@@ -7,11 +7,11 @@ import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import org.hibernate.annotations.CreationTimestamp
 import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.Instant
-import java.util.*
+import java.util.UUID
 
 @Entity
 @EntityListeners(value = [AuditingEntityListener::class])
@@ -36,7 +36,7 @@ data class TimelineEntity(
   @Column(updatable = false)
   var createdBy: String? = null,
 
-  @CreationTimestamp
+  @CreatedDate
   @Column(updatable = false)
   var createdAt: Instant? = null,
 


### PR DESCRIPTION
PR to use the Spring annotations rather than the hibernate ones for setting the "created at" and "updated at" timestamps.

The reason we need to do this is because the hibernate ones do not allow the injection of a clock or similar, so we cannot control the timestamps being set in tests.
In contrast, the Spring annotations will make use of a `DateTimeProvider` bean if one exists, so as well as using the Spring annotations, this PR also provides a `DateTimeProvider` bean which in turn uses our `Clock` bean 👍 

(this will allow us to enable the SAR integration test and set a fixed clock in the integration test context; all of which will come in my next PR)