### PR TITLE
RR-2554: Add DELETE endpoint for conditions

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/resource/DeleteConditionTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/resource/DeleteConditionTest.kt
@@ -1,0 +1,429 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ConditionEntity
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.Domain
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.PlanCreationScheduleStatus
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ReferenceDataKey
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.Source
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.TimelineEventType
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.randomValidPrisonNumber
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.ConditionListResponse
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.ConditionRequest
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.CreateConditionsRequest
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.ErrorResponse
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.assertThat
+import java.util.UUID
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.Source as ModelSource
+
+class DeleteConditionTest : IntegrationTestBase() {
+  companion object {
+    private const val URI_TEMPLATE = "/profile/{prisonNumber}/conditions/{reference}"
+    private const val DEFAULT_QUERY = "?prisonId=BXI&reason=ENTERED_IN_ERROR"
+  }
+
+  @Test
+  fun `delete a condition for a given prisoner`() {
+    // Given
+    stubGetTokenFromHmppsAuth()
+    stubGetDisplayName("testuser")
+    val prisonNumber = randomValidPrisonNumber()
+
+    val adhd = referenceDataRepository.findByKey(ReferenceDataKey(Domain.CONDITION, "ADHD"))
+      ?: throw IllegalStateException("Reference data not found")
+
+    val condition = conditionRepository.saveAndFlush(
+      ConditionEntity(
+        prisonNumber = prisonNumber,
+        source = Source.SELF_DECLARED,
+        conditionType = adhd,
+        createdAtPrison = "BXI",
+        updatedAtPrison = "BXI",
+      ),
+    )
+
+    // When
+    webTestClient.delete()
+      .uri("$URI_TEMPLATE$DEFAULT_QUERY", prisonNumber, condition.reference)
+      .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW"), username = "testuser"))
+      .exchange()
+      .expectStatus()
+      .isNoContent
+
+    // Then
+    val conditions = conditionRepository.findAllByPrisonNumber(prisonNumber)
+    assertThat(conditions).isEmpty()
+  }
+
+  @Test
+  fun `delete one of several conditions for a prisoner leaves the others`() {
+    // Given
+    stubGetTokenFromHmppsAuth()
+    stubGetDisplayName("testuser")
+    val prisonNumber = randomValidPrisonNumber()
+
+    val adhd = referenceDataRepository.findByKey(ReferenceDataKey(Domain.CONDITION, "ADHD"))
+      ?: throw IllegalStateException("Reference data not found")
+    val dyslexia = referenceDataRepository.findByKey(ReferenceDataKey(Domain.CONDITION, "DYSLEXIA"))
+      ?: throw IllegalStateException("Reference data not found")
+
+    val adhdCondition = conditionRepository.saveAndFlush(
+      ConditionEntity(
+        prisonNumber = prisonNumber,
+        source = Source.SELF_DECLARED,
+        conditionType = adhd,
+        createdAtPrison = "BXI",
+        updatedAtPrison = "BXI",
+      ),
+    )
+    val dyslexiaCondition = conditionRepository.saveAndFlush(
+      ConditionEntity(
+        prisonNumber = prisonNumber,
+        source = Source.SELF_DECLARED,
+        conditionType = dyslexia,
+        createdAtPrison = "BXI",
+        updatedAtPrison = "BXI",
+      ),
+    )
+
+    // When
+    webTestClient.delete()
+      .uri("$URI_TEMPLATE$DEFAULT_QUERY", prisonNumber, adhdCondition.reference)
+      .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW"), username = "testuser"))
+      .exchange()
+      .expectStatus()
+      .isNoContent
+
+    // Then
+    val remaining = conditionRepository.findAllByPrisonNumber(prisonNumber)
+    assertThat(remaining).hasSize(1)
+    assertThat(remaining.first().reference).isEqualTo(dyslexiaCondition.reference)
+    assertThat(remaining.first().conditionType.key.code).isEqualTo("DYSLEXIA")
+  }
+
+  @Test
+  fun `delete an archived (inactive) condition`() {
+    // Given
+    stubGetTokenFromHmppsAuth()
+    stubGetDisplayName("testuser")
+    val prisonNumber = randomValidPrisonNumber()
+
+    val adhd = referenceDataRepository.findByKey(ReferenceDataKey(Domain.CONDITION, "ADHD"))
+      ?: throw IllegalStateException("Reference data not found")
+
+    val condition = conditionRepository.saveAndFlush(
+      ConditionEntity(
+        prisonNumber = prisonNumber,
+        source = Source.SELF_DECLARED,
+        conditionType = adhd,
+        createdAtPrison = "BXI",
+        updatedAtPrison = "BXI",
+        active = false,
+        archiveReason = "previously archived",
+      ),
+    )
+
+    // When
+    webTestClient.delete()
+      .uri("$URI_TEMPLATE$DEFAULT_QUERY", prisonNumber, condition.reference)
+      .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW"), username = "testuser"))
+      .exchange()
+      .expectStatus()
+      .isNoContent
+
+    // Then
+    val conditions = conditionRepository.findAllByPrisonNumber(prisonNumber)
+    assertThat(conditions).isEmpty()
+  }
+
+  @Test
+  fun `delete a condition that does not exist for the prisoner`() {
+    // Given
+    stubGetTokenFromHmppsAuth()
+    stubGetDisplayName("testuser")
+    val prisonNumber = randomValidPrisonNumber()
+    val ref = UUID.randomUUID()
+
+    // When
+    val response = webTestClient.delete()
+      .uri("$URI_TEMPLATE$DEFAULT_QUERY", prisonNumber, ref)
+      .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW"), username = "testuser"))
+      .exchange()
+      .expectStatus()
+      .isNotFound
+      .returnResult(ErrorResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .hasStatus(HttpStatus.NOT_FOUND.value())
+      .hasUserMessage("Condition with reference [$ref] not found for prisoner [$prisonNumber]")
+  }
+
+  @Test
+  fun `delete a condition belonging to a different prisoner`() {
+    // Given
+    stubGetTokenFromHmppsAuth()
+    stubGetDisplayName("testuser")
+    val prisonerA = randomValidPrisonNumber()
+    val prisonerB = randomValidPrisonNumber()
+
+    val adhd = referenceDataRepository.findByKey(ReferenceDataKey(Domain.CONDITION, "ADHD"))
+      ?: throw IllegalStateException("Reference data not found")
+
+    val condition = conditionRepository.saveAndFlush(
+      ConditionEntity(
+        prisonNumber = prisonerA,
+        source = Source.SELF_DECLARED,
+        conditionType = adhd,
+        createdAtPrison = "BXI",
+        updatedAtPrison = "BXI",
+      ),
+    )
+
+    // When — try to delete prisonerA's condition under prisonerB's path
+    val response = webTestClient.delete()
+      .uri("$URI_TEMPLATE$DEFAULT_QUERY", prisonerB, condition.reference)
+      .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW"), username = "testuser"))
+      .exchange()
+      .expectStatus()
+      .isNotFound
+      .returnResult(ErrorResponse::class.java)
+
+    // Then
+    val actual = response.responseBody.blockFirst()
+    assertThat(actual)
+      .hasStatus(HttpStatus.NOT_FOUND.value())
+      .hasUserMessage("Condition with reference [${condition.reference}] not found for prisoner [$prisonerB]")
+
+    // and the original is untouched
+    assertThat(conditionRepository.findAllByPrisonNumber(prisonerA)).hasSize(1)
+  }
+
+  @Test
+  fun `delete a condition with no role`() {
+    // Given
+    stubGetTokenFromHmppsAuth()
+    stubGetDisplayName("testuser")
+    val prisonNumber = randomValidPrisonNumber()
+    val ref = UUID.randomUUID()
+
+    // When
+    webTestClient.delete()
+      .uri("$URI_TEMPLATE$DEFAULT_QUERY", prisonNumber, ref)
+      .headers(setAuthorisation(roles = listOf(), username = "testuser"))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `delete a condition with wrong role`() {
+    // Given
+    stubGetTokenFromHmppsAuth()
+    stubGetDisplayName("testuser")
+    val prisonNumber = randomValidPrisonNumber()
+    val ref = UUID.randomUUID()
+
+    // When — read-only role cannot delete
+    webTestClient.delete()
+      .uri("$URI_TEMPLATE$DEFAULT_QUERY", prisonNumber, ref)
+      .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RO"), username = "testuser"))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `delete a condition without prisonId query param`() {
+    // Given
+    stubGetTokenFromHmppsAuth()
+    stubGetDisplayName("testuser")
+    val prisonNumber = randomValidPrisonNumber()
+    val ref = UUID.randomUUID()
+
+    // When
+    webTestClient.delete()
+      .uri("$URI_TEMPLATE?reason=ENTERED_IN_ERROR", prisonNumber, ref)
+      .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW"), username = "testuser"))
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+  }
+
+  @Test
+  fun `delete a condition without reason query param`() {
+    // Given
+    stubGetTokenFromHmppsAuth()
+    stubGetDisplayName("testuser")
+    val prisonNumber = randomValidPrisonNumber()
+    val ref = UUID.randomUUID()
+
+    // When
+    webTestClient.delete()
+      .uri("$URI_TEMPLATE?prisonId=BXI", prisonNumber, ref)
+      .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW"), username = "testuser"))
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+  }
+
+  @Test
+  fun `delete a condition with an unknown reason value`() {
+    // Given
+    stubGetTokenFromHmppsAuth()
+    stubGetDisplayName("testuser")
+    val prisonNumber = randomValidPrisonNumber()
+    val ref = UUID.randomUUID()
+
+    // When
+    webTestClient.delete()
+      .uri("$URI_TEMPLATE?prisonId=BXI&reason=NOT_A_REAL_REASON", prisonNumber, ref)
+      .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW"), username = "testuser"))
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+  }
+
+  @Test
+  fun `deleting the only need-source cascades schedule to EXEMPT_NO_NEED`() {
+    // Given
+    stubForBankHoliday()
+    stubGetTokenFromHmppsAuth()
+    stubGetDisplayName("testuser")
+    val prisonNumber = randomValidPrisonNumber()
+    prisonerInEducation(prisonNumber)
+
+    // create a single condition via the existing API so the schedule is set up correctly
+    val createResponse = webTestClient.post()
+      .uri("/profile/{prisonNumber}/conditions", prisonNumber)
+      .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW"), username = "testuser"))
+      .bodyValue(
+        CreateConditionsRequest(
+          listOf(
+            ConditionRequest(
+              source = ModelSource.SELF_DECLARED,
+              prisonId = "BXI",
+              conditionTypeCode = "ADHD",
+            ),
+          ),
+        ),
+      )
+      .exchange()
+      .expectStatus()
+      .isCreated
+      .returnResult(ConditionListResponse::class.java)
+
+    val created = createResponse.responseBody.blockFirst()!!
+    val conditionReference = created.conditions.first().reference
+
+    val scheduleBefore = planCreationScheduleRepository.findByPrisonNumber(prisonNumber)
+    assertThat(scheduleBefore?.status).isEqualTo(PlanCreationScheduleStatus.SCHEDULED)
+
+    // When
+    webTestClient.delete()
+      .uri("$URI_TEMPLATE$DEFAULT_QUERY", prisonNumber, conditionReference)
+      .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW"), username = "testuser"))
+      .exchange()
+      .expectStatus()
+      .isNoContent
+
+    // Then
+    assertThat(needService.hasNeed(prisonNumber)).isFalse()
+    val scheduleAfter = planCreationScheduleRepository.findByPrisonNumber(prisonNumber)
+    assertThat(scheduleAfter?.status).isEqualTo(PlanCreationScheduleStatus.EXEMPT_NO_NEED)
+  }
+
+  @Test
+  fun `deleting one condition does NOT cascade when prisoner still has another need source`() {
+    // Given
+    stubForBankHoliday()
+    stubGetTokenFromHmppsAuth()
+    stubGetDisplayName("testuser")
+    val prisonNumber = randomValidPrisonNumber()
+    prisonerInEducation(prisonNumber)
+
+    val createResponse = webTestClient.post()
+      .uri("/profile/{prisonNumber}/conditions", prisonNumber)
+      .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW"), username = "testuser"))
+      .bodyValue(
+        CreateConditionsRequest(
+          listOf(
+            ConditionRequest(
+              source = ModelSource.SELF_DECLARED,
+              prisonId = "BXI",
+              conditionTypeCode = "ADHD",
+            ),
+            ConditionRequest(
+              source = ModelSource.SELF_DECLARED,
+              prisonId = "BXI",
+              conditionTypeCode = "DYSLEXIA",
+            ),
+          ),
+        ),
+      )
+      .exchange()
+      .expectStatus()
+      .isCreated
+      .returnResult(ConditionListResponse::class.java)
+
+    val created = createResponse.responseBody.blockFirst()!!
+    val adhdReference = created.conditions.first { it.conditionType.code == "ADHD" }.reference
+
+    val scheduleBefore = planCreationScheduleRepository.findByPrisonNumber(prisonNumber)
+    assertThat(scheduleBefore?.status).isEqualTo(PlanCreationScheduleStatus.SCHEDULED)
+
+    // When
+    webTestClient.delete()
+      .uri("$URI_TEMPLATE$DEFAULT_QUERY", prisonNumber, adhdReference)
+      .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW"), username = "testuser"))
+      .exchange()
+      .expectStatus()
+      .isNoContent
+
+    // Then
+    assertThat(needService.hasNeed(prisonNumber)).isTrue()
+    val scheduleAfter = planCreationScheduleRepository.findByPrisonNumber(prisonNumber)
+    assertThat(scheduleAfter?.status).isEqualTo(PlanCreationScheduleStatus.SCHEDULED)
+  }
+
+  @Test
+  fun `delete records a CONDITION_DELETED timeline event with reference and reason in additionalInfo`() {
+    // Given
+    stubGetTokenFromHmppsAuth()
+    stubGetDisplayName("testuser")
+    val prisonNumber = randomValidPrisonNumber()
+
+    val adhd = referenceDataRepository.findByKey(ReferenceDataKey(Domain.CONDITION, "ADHD"))
+      ?: throw IllegalStateException("Reference data not found")
+
+    val condition = conditionRepository.saveAndFlush(
+      ConditionEntity(
+        prisonNumber = prisonNumber,
+        source = Source.SELF_DECLARED,
+        conditionType = adhd,
+        createdAtPrison = "BXI",
+        updatedAtPrison = "BXI",
+      ),
+    )
+
+    // When
+    webTestClient.delete()
+      .uri("$URI_TEMPLATE$DEFAULT_QUERY", prisonNumber, condition.reference)
+      .headers(setAuthorisation(roles = listOf("ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW"), username = "testuser"))
+      .exchange()
+      .expectStatus()
+      .isNoContent
+
+    // Then
+    val timelineEntries = timelineRepository.findAllByPrisonNumberOrderByCreatedAt(prisonNumber)
+    val deletionEntry = timelineEntries.firstOrNull { it.event == TimelineEventType.CONDITION_DELETED }
+    assertThat(deletionEntry).isNotNull()
+    assertThat(deletionEntry!!.additionalInfo)
+      .isEqualTo("conditionReference=${condition.reference}|reason=ENTERED_IN_ERROR")
+    assertThat(deletionEntry.createdAtPrison).isEqualTo("BXI")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/DeletionReason.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/DeletionReason.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity
+
+enum class DeletionReason {
+  DATA_PROCESSING_OBJECTION,
+  ENTERED_IN_ERROR,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/TimelineEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/domain/entity/TimelineEntity.kt
@@ -44,6 +44,7 @@ data class TimelineEntity(
 
 enum class TimelineEventType {
   CONDITION_ADDED,
+  CONDITION_DELETED,
   CHALLENGE_ADDED,
   ALN_CHALLENGE_ADDED,
   ALN_STRENGTH_ADDED,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/resource/ConditionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/resource/ConditionController.kt
@@ -3,14 +3,17 @@ package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.DeletionReason
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.ArchiveConditionRequest
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.ConditionListResponse
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.resource.model.ConditionResponse
@@ -61,5 +64,17 @@ class ConditionController(private val conditionService: ConditionService) {
     @Valid @RequestBody request: ArchiveConditionRequest,
   ) {
     conditionService.archiveCondition(prisonNumber, conditionReference, request)
+  }
+
+  @DeleteMapping("/{conditionReference}")
+  @PreAuthorize(HAS_EDIT_ELSP)
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  fun deleteCondition(
+    @PathVariable prisonNumber: String,
+    @PathVariable conditionReference: UUID,
+    @RequestParam prisonId: String,
+    @RequestParam reason: DeletionReason,
+  ) {
+    conditionService.deleteCondition(prisonNumber, conditionReference, prisonId, reason)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/ConditionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/ConditionService.kt
@@ -3,10 +3,12 @@ package uk.gov.justice.digital.hmpps.supportadditionalneedsapi.service
 import jakarta.transaction.Transactional
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.DeletionReason
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.Domain
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ReferenceDataEntity
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.ReferenceDataKey
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.TimelineEventType.CONDITION_ADDED
+import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.entity.TimelineEventType.CONDITION_DELETED
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.ConditionRepository
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.ReferenceDataRepository
 import uk.gov.justice.digital.hmpps.supportadditionalneedsapi.domain.repository.validateReferenceData
@@ -115,5 +117,27 @@ class ConditionService(
       log.info("The condition update did not change the overall need of $prisonNumber")
     }
     log.info("Processed Archive condition for $prisonNumber")
+  }
+
+  @Transactional
+  @TimelineEvent(
+    eventType = CONDITION_DELETED,
+    additionalInfoField = "conditionReference,reason",
+  )
+  fun deleteCondition(prisonNumber: String, conditionReference: UUID, prisonId: String, reason: DeletionReason) {
+    val condition = conditionRepository.getConditionEntityByPrisonNumberAndReference(prisonNumber, conditionReference)
+      ?: throw ConditionNotFoundException(prisonNumber, conditionReference)
+
+    conditionRepository.delete(condition)
+
+    // has this changed the prisoner's need? do we need to update MN?
+    val hasNeed = needService.hasNeed(prisonNumber = prisonNumber)
+    if (!hasNeed) {
+      log.info("Prisoner $prisonNumber no longer has a need due to deleted condition.")
+      scheduleService.processNeedChange(prisonNumber, hasNeed, prisonId = prisonId)
+    } else {
+      log.info("The condition deletion did not change the overall need of $prisonNumber")
+    }
+    log.info("Processed Delete condition for $prisonNumber")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/timeline/TimelineAspect.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/supportadditionalneedsapi/service/timeline/TimelineAspect.kt
@@ -36,7 +36,7 @@ class TimelineAspect(
     val prisonCode = resolvePrisonCode(argMap, itemList.first())
 
     val entries = itemList.map { item ->
-      val additionalInfo = resolveAdditionalInfo(item, timelineEvent)
+      val additionalInfo = resolveAdditionalInfo(item, argMap, timelineEvent)
       TimelineEntity(
         id = UUID.randomUUID(),
         prisonNumber = prisonNumber,
@@ -55,9 +55,26 @@ class TimelineAspect(
     ?: extractField(fallbackItem, "prisonId")
     ?: DEFAULT_PRISON_ID
 
-  private fun resolveAdditionalInfo(item: Any, timelineEvent: TimelineEvent): String = extractField(item, timelineEvent.additionalInfoField)
-    ?.let { "${timelineEvent.additionalInfoPrefix}$it" }
-    ?: "UNKNOWN_TYPE"
+  private fun resolveAdditionalInfo(item: Any, argMap: Map<String, Any?>, timelineEvent: TimelineEvent): String {
+    val fieldNames = timelineEvent.additionalInfoField
+      .split(",")
+      .map(String::trim)
+      .filter { it.isNotEmpty() }
+    if (fieldNames.isEmpty()) return "UNKNOWN_TYPE"
+
+    val resolved = fieldNames.mapNotNull { name ->
+      (extractField(item, name) ?: argMap[name]?.toString())?.let { name to it }
+    }
+    if (resolved.isEmpty()) return "UNKNOWN_TYPE"
+
+    if (fieldNames.size == 1) {
+      val (_, value) = resolved.first()
+      return "${timelineEvent.additionalInfoPrefix}$value"
+    }
+
+    val body = resolved.joinToString("|") { (name, value) -> "$name=$value" }
+    return "${timelineEvent.additionalInfoPrefix}$body"
+  }
 
   private fun resolveItemList(argMap: Map<String, Any?>): List<Any>? {
     // Case 1: a raw list (e.g. List<ChallengeRequest>)

--- a/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
+++ b/src/main/resources/static/openapi/SupportAdditionalNeedsAPI.yml
@@ -1,7 +1,7 @@
 openapi: 3.1.1
 info:
   title: Support For Additional Needs API
-  version: '0.17.2'
+  version: '0.18.0'
   description: Support For Additional Needs API
   contact:
     name: Learning and Work Progress team
@@ -300,6 +300,41 @@ paths:
           $ref: '#/components/responses/400Error'
         '404':
           description: Condition not found
+    delete:
+      summary: Deletes a single condition by UUID.
+      description: |
+        Hard-deletes the specified condition. Whether the condition was previously archived
+        (`active = false`) or still live, it is deleted in the same way. If the condition was
+        the prisoner's only "need" source, the prisoner's plan-creation/review schedules are
+        marked `EXEMPT_NO_NEED` and an `san.plan-creation-schedule.updated` /
+        `san.review-schedule.updated` event is published so MN can pick up the change.
+
+        **Role Requirements:**
+        Access to this endpoint requires one of the following roles:
+          - `ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW` (Read-Write)
+      tags:
+        - Condition
+      operationId: delete-condition
+      parameters:
+        - name: prisonId
+          in: query
+          required: true
+          schema:
+            type: string
+          description: The prison code making the change (drives `updatedAtPrison` on cascaded schedule updates and `createdAtPrison` on the timeline row).
+        - name: reason
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/DeletionReason'
+          description: The reason for deletion. Stored in the timeline event's `additionalInfo`.
+      responses:
+        '204':
+          description: The condition was successfully deleted.
+        '400':
+          $ref: '#/components/responses/400Error'
+        '404':
+          $ref: '#/components/responses/404Error'
 
   '/profile/{prisonNumber}/ehcp-status':
     parameters:
@@ -2630,6 +2665,13 @@ components:
       required:
         - archiveReason
         - prisonId
+
+    DeletionReason:
+      type: string
+      enum:
+        - DATA_PROCESSING_OBJECTION
+        - ENTERED_IN_ERROR
+      description: Reason for deleting a record.
 
 
     SupportStrategyRequest:


### PR DESCRIPTION
This change introduces a new API endpoint to hard-delete a specified condition for a prisoner.

The deletion is recorded as a `CONDITION_DELETED` timeline event, including the deletion reason provided. If the deleted condition was the prisoner's last active 'need' source, the plan creation schedule is updated to `EXEMPT_NO_NEED`, triggering a notification to other systems.

The endpoint requires `prisonId` and `reason` query parameters and `ROLE_SUPPORT_ADDITIONAL_NEEDS__ELSP__RW` role.
